### PR TITLE
redraw the connecting line as soon as the user has clicked on a port.

### DIFF
--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -165,7 +165,11 @@ bool Connection::hitTest(int x, int y)
     auto pend = getEndPoint().toFloat();
     
     if (cnv->isSelected(this) && (startReconnectHandle.contains(position) || endReconnectHandle.contains(position)))
+    {
+        outlet->repaint();
+        inlet->repaint();
         return true;
+    }
     
     // If we click too close to the inlet, don't register the click on the connection
     if (pstart.getDistanceFrom(position + getPosition().toFloat()) < 8.0f || pend.getDistanceFrom(position + getPosition().toFloat()) < 8.0f)


### PR DESCRIPTION
Fix connection behaviour when a user clicks on a port and drags in one action:
![connection_bug](https://user-images.githubusercontent.com/12004932/206884908-d6160073-00b8-468e-a67c-74716b8c172e.gif)

We have to redraw the connection when the user has clicked
![connection_fix](https://user-images.githubusercontent.com/12004932/206884911-81bbc6c6-2ea5-4515-b555-612c1387e9c8.gif)
