### PR TITLE
use scaling to change size of toggle cross instead of fixed pixel size

### DIFF
--- a/Source/Objects/ToggleObject.h
+++ b/Source/Objects/ToggleObject.h
@@ -28,7 +28,7 @@ struct ToggleObject final : public IEMObject {
         auto untoggledColour = toggledColour.interpolatedWith(getBackgroundColour(), 0.8f);
         g.setColour(toggleState ? toggledColour : untoggledColour);
 
-        auto crossBounds = getLocalBounds().reduced(6).toFloat();
+        auto crossBounds = getLocalBounds().reduced(getWidth() * 0.08f).toFloat();
 
         if (getWidth() < 20) {
             crossBounds = crossBounds.expanded(20 - getWidth());


### PR DESCRIPTION
Currently the toggle cross size is fixed to 6px away from edge
![cross_fixed](https://user-images.githubusercontent.com/12004932/206940920-c1b5984c-c82b-4f51-83a8-6c3e809e5c8d.gif)

Use scaling of the object width to scale the cross, so it's consistent when size is changed
![cross_scale](https://user-images.githubusercontent.com/12004932/206940924-ec143703-3be0-47e1-86b7-f44ea4d96ca8.gif)
