### PR TITLE
comment display issue

### DIFF
--- a/Source/Objects/TextObject.h
+++ b/Source/Objects/TextObject.h
@@ -41,7 +41,7 @@ struct TextBase : public ObjectBase
         width = std::max(width, std::max({ 1, object->numInputs, object->numOutputs }) * 18);
 
         numLines = getNumLines(objectText, width);
-        int height = numLines * 15 + 6;
+        int height = numLines * 20;
 
         if (getWidth() != width || getHeight() != height) {
             object->setSize(width + Object::doubleMargin, height + Object::doubleMargin);
@@ -135,7 +135,7 @@ struct TextBase : public ObjectBase
         width = std::max(width, std::max({ 1, object->numInputs, object->numOutputs }) * 18);
 
         numLines = getNumLines(objectText, width);
-        int height = numLines * 15 + 6;
+        int height = numLines * 20;
 
         bounds.setWidth(width);
         bounds.setHeight(height);


### PR DESCRIPTION
it used to look like this
![Screenshot_2022-12-17_21-46-36](https://user-images.githubusercontent.com/86204514/208298636-8b82ae36-d604-470b-8a4e-77f8d9d7715a.png)
making the documentation hard to read. i did this and it looks right
![Screenshot_2022-12-18_14-28-16](https://user-images.githubusercontent.com/86204514/208298658-b53a7b75-692a-4555-b062-cd5b1c234d6e.png)

please sanity-check this, i have no clue what i'm doing :D