### PR TITLE
fix scope freeze when changing buffer size

### DIFF
--- a/Source/Objects/ScopeObject.h
+++ b/Source/Objects/ScopeObject.h
@@ -290,6 +290,7 @@ struct ScopeBase : public GUIObject
         } else if (v.refersToSameSourceAs(bufferSize)) {
             bufferSize = std::clamp<int>(static_cast<int>(bufferSize.getValue()), 0, SCOPE_MAXBUFSIZE * 4);
             scope->x_bufsize = bufferSize.getValue();
+            scope->x_bufphase = 0;
         } else if (v.refersToSameSourceAs(samplesPerPoint)) {
             scope->x_period = limitValueMin(v, 0);
         } else if (v.refersToSameSourceAs(signalRange)) {


### PR DESCRIPTION
* when changing the buffer size we also need to reset the buffer phase, otherwise the phase could be larger than the current buffer size