### PR TITLE
use a value listener to hide/show connections

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -1133,13 +1133,7 @@ void Canvas::valueChanged(Value& v)
     // Should only get called when the canvas isn't a real graph
     else if (v.refersToSameSourceAs(presentationMode)) {
         deselectAll();
-
-        if (presentationMode == var(true))
-            connections.clear();
-
         commandLocked.setValue(presentationMode.getValue());
-
-        synchronise();
     } else if (v.refersToSameSourceAs(isGraphChild)) {
         patch.getPointer()->gl_isgraph = static_cast<bool>(isGraphChild.getValue());
 

--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -16,8 +16,9 @@ Connection::Connection(Canvas* parent, Iolet* s, Iolet* e, bool exists)
     , outobj(outlet->object)
     , inobj(inlet->object)
 {
-
     locked.referTo(parent->locked);
+    presentationMode.referTo(parent->presentationMode);
+    presentationMode.addListener(this);
 
     // Make sure it's not 2x the same iolet
     if (!outlet || !inlet || outlet->isInlet == inlet->isInlet) {
@@ -85,6 +86,9 @@ void Connection::valueChanged(Value& v)
 {
     if (v.refersToSameSourceAs(useDashedSignalConnection)) {
         useDashed = static_cast<bool>(useDashedSignalConnection.getValue());
+    }
+    else if (v.refersToSameSourceAs(presentationMode)) {
+        setVisible(presentationMode == var(true) ? false : true);
     }
 }
 

--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -82,6 +82,7 @@ private:
     PathPlan currentPlan;
 
     Value locked;
+    Value presentationMode;
 
     Canvas* cnv;
 


### PR DESCRIPTION
Currently when presentation mode is entered - we delete all connections, and regenerate them when exited.

This PR connects a value listener to the presentation mode value, and simply hides/shows connections when needed.