### PR TITLE
Fix first launch issue.

### DIFF
--- a/Source/Pd/PdInstance.h
+++ b/Source/Pd/PdInstance.h
@@ -282,6 +282,7 @@ public:
     Instance(Instance const& other) = delete;
     virtual ~Instance();
 
+    void loadLibs();
     void prepareDSP(int const nins, int const nouts, double const samplerate, int const blockSize);
     void startDSP();
     void releaseDSP();

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -174,6 +174,10 @@ PluginProcessor::PluginProcessor()
 
     updateSearchPaths();
 
+    // ag: This needs to be done *after* the library data has been unpacked on
+    // first launch.
+    loadLibs();
+
     setLatencySamples(pd::Instance::getBlockSize());
 
 #if PLUGDATA_STANDALONE && !JUCE_WINDOWS


### PR DESCRIPTION
Make sure to defer external initialization until after unpacking library data on first launch.

This is a bit quirky since I had to move the externals initialization stuff into its own loadLibs method which then gets invoked from PluginProcessor once the library data directory has been populated at first launch. Also, I had to move the initialization of m_print_receiver to the same method in order to suppress the console output of chatty externals. Maybe you can find a better way, but this is the best I could come up with without rocking the boat too much. :)

Note that loadLibs will have to be invoked from any class which derives from Instance or has it as a member. The only such class seems to be PluginProcessor, but maybe double-check this to make sure.

With the abstraction path issue resolved in rev. c278b206dc9001d551efaf03812bac34ad47e66f, this closes #315. 