### PR TITLE
reset drag index to -1 when deleting point

### DIFF
--- a/Source/Objects/FunctionObject.h
+++ b/Source/Objects/FunctionObject.h
@@ -224,6 +224,7 @@ struct FunctionObject final : public GUIObject {
             if (clickBounds.contains(e.x, e.y)) {
                 dragIdx = i;
                 if (e.getNumberOfClicks() == 2) {
+                    dragIdx = -1;
                     if (i == 0 || i == realPoints.size() - 1) {
                         points.getReference(i).y = 0.0f;
                         resetHoverIdx();


### PR DESCRIPTION
Otherwise there is a bug where deleting a point  (double clicking) but keeping the mouse down (drag) will move the last point)