### PR TITLE
pd-lua: use live version data.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -85,6 +86,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -140,6 +142,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -194,6 +197,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -257,6 +261,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -323,6 +328,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
         env:
           PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -369,6 +375,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 0
       env:
         PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         
@@ -416,6 +423,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 0
       env:
         PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -463,6 +471,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 0
       env:
         PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -302,6 +302,11 @@ set(PDLUA_SOURCES ${PDLUA_PATH}/pdlua.c)
 
 source_group(pdlua FILES ${PDLUA_SOURCES})
 
+# live version data for pdlua.c
+# set(PDLUA_VERSION 0.11.0)
+execute_process(COMMAND git -C ${CMAKE_CURRENT_SOURCE_DIR}/pd-lua describe --tags OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE PDLUA_VERSION)
+set_source_files_properties(${PDLUA_PATH}/pdlua.c PROPERTIES COMPILE_DEFINITIONS PDLUA_VERSION=${PDLUA_VERSION})
+
 # ------------------------------------------------------------------------------#
 # COMPILE DEFINITIONS
 # ------------------------------------------------------------------------------#

--- a/Libraries/libpd/x_libpd_multi.c
+++ b/Libraries/libpd/x_libpd_multi.c
@@ -740,11 +740,11 @@ void xselect_tilde_setup();
 void xselect2_tilde_setup();
 void zerocross_tilde_setup();
 
-void pdlua_setup(const char *datadir);
+void pdlua_setup(const char *datadir, char *vers, int vers_len);
 
-void libpd_init_pdlua(const char *datadir)
+void libpd_init_pdlua(const char *datadir, char *vers, int vers_len)
 {
-    pdlua_setup(datadir);
+    pdlua_setup(datadir, vers, vers_len);
 }
 
 void libpd_init_else(void)

--- a/Libraries/libpd/x_libpd_multi.h
+++ b/Libraries/libpd/x_libpd_multi.h
@@ -15,7 +15,7 @@ extern "C" {
 void libpd_multi_init(void);
 void libpd_init_else(void);
 void libpd_init_cyclone(void);
-void libpd_init_pdlua(const char *datadir);
+void libpd_init_pdlua(const char *datadir, char *vers, int vers_len);
 
 typedef void (*t_libpd_multi_banghook)(void* ptr, char const* recv);
 typedef void (*t_libpd_multi_floathook)(void* ptr, char const* recv, float f);

--- a/Source/Pd/PdInstance.cpp
+++ b/Source/Pd/PdInstance.cpp
@@ -257,14 +257,17 @@ Instance::~Instance()
 }
 
 // ag: Stuff to be done after unpacking the library data on first launch.
-void Instance::loadLibs()
+void Instance::loadLibs(String &pdlua_version)
 {
     libpd_init_else();
     libpd_init_cyclone();
     File homeDir = File::getSpecialLocation(File::SpecialLocationType::userApplicationDataDirectory).getChildFile("plugdata");
     auto library = homeDir.getChildFile("Library");
     auto extra = library.getChildFile("Extra");
-    libpd_init_pdlua(extra.getFullPathName().getCharPointer());
+    char vers[1000];
+    *vers = 0;
+    libpd_init_pdlua(extra.getFullPathName().getCharPointer(), vers, 1000);
+    if (*vers) pdlua_version = vers;
     // ag: need to do this here to suppress noise from chatty externals
     m_print_receiver = libpd_multi_print_new(this, reinterpret_cast<t_libpd_multi_printhook>(internal::instance_multi_print));
     libpd_set_verbose(0);

--- a/Source/Pd/PdInstance.h
+++ b/Source/Pd/PdInstance.h
@@ -282,7 +282,7 @@ public:
     Instance(Instance const& other) = delete;
     virtual ~Instance();
 
-    void loadLibs();
+    void loadLibs(String &pdlua_version);
     void prepareDSP(int const nins, int const nouts, double const samplerate, int const blockSize);
     void startDSP();
     void releaseDSP();

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -45,6 +45,10 @@ AudioProcessor::BusesProperties PluginProcessor::buildBusesProperties()
     return busesProperties;
 }
 
+// ag: Note that this is just a fallback, we update this with live version
+// data from the external if we have it.
+String PluginProcessor::pdlua_version = "pdlua 0.11.0 (lua 5.4)";
+
 PluginProcessor::PluginProcessor()
 #ifndef JucePlugin_PreferredChannelConfigurations
     : AudioProcessor(buildBusesProperties())
@@ -105,7 +109,6 @@ PluginProcessor::PluginProcessor()
     logMessage("Libraries:");
     logMessage(else_version);
     logMessage(cyclone_version);
-    logMessage(pdlua_version);
 
     channelPointers.reserve(32);
 
@@ -172,7 +175,8 @@ PluginProcessor::PluginProcessor()
 
     // ag: This needs to be done *after* the library data has been unpacked on
     // first launch.
-    loadLibs();
+    loadLibs(pdlua_version);
+    logMessage(pdlua_version);
     
     // scope for locking message manager
     {

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -196,9 +196,8 @@ private:
 
     static inline const String else_version = "ELSE v1.0-rc5";
     static inline const String cyclone_version = "cyclone v0.6-1";
-    // XXXFIXME: These version numbers should really be determined by cmake,
-    // as they depend on the build system and bundled pd-lua version. -ag
-    static inline const String pdlua_version = "pdlua 0.10.2 (Lua 5.4)";
+    // this gets updated with live version data later
+    static String pdlua_version;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PluginProcessor)
 };


### PR DESCRIPTION
Last time I forgot to update the pd-lua version number, so I used the opportunity to implement the live version data scheme I proposed in https://github.com/agraef/pd-lua/pull/23#issuecomment-1374893748.

This makes sure that pd-lua version information is determined automatically at compile time, no need to manually edit the version number in the plugdata source any more, but it requires some tie-ins between the external source and plugdata.

pd-lua submodule updated to the latest from upstream, thus a `git submodule update --init --recursive` is in order.

You may consider to give some similar treatment to cyclone and ELSE. :)