### PR TITLE
Fix shift+drag crash

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -1460,7 +1460,7 @@ void Canvas::handleMouseDrag(MouseEvent const& e)
 
     if (e.mods.isShiftDown() && selection.size() == 1) {
         auto* object = selection.getFirst();
-        if (object->numInputs >= 1 && object->numOutputs >= 0) {
+        if (object->numInputs && object->numOutputs) {
             bool intersected = false;
             for (auto* connection : connections) {
                 if (connection->intersectsObject(object)) {


### PR DESCRIPTION
Fix shift+drag crash, when dragged object doesn't have any outlets