### PR TITLE
KeyMap init settings fix

### DIFF
--- a/Source/Dialogs/KeyMappingPanel.h
+++ b/Source/Dialogs/KeyMappingPanel.h
@@ -51,10 +51,10 @@ public:
     void changeListenerCallback(ChangeBroadcaster* source) override
     {
         auto newTree = mappings.createXml(true)->toString();
-        if (settingsTree.getChildWithName("Keymap").isValid()) {
-            settingsTree.getChildWithName("Keymap").setProperty("keyxml", newTree, nullptr);
+        if (settingsTree.getChildWithName("KeyMap").isValid()) {
+            settingsTree.getChildWithName("KeyMap").setProperty("keyxml", newTree, nullptr);
         } else {
-            auto keyMap = ValueTree("Keymap");
+            auto keyMap = ValueTree("KeyMap");
             keyMap.setProperty("keyxml", newTree, nullptr);
             settingsTree.appendChild(keyMap, nullptr);
         }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -81,7 +81,7 @@ PluginEditor::PluginEditor(PluginProcessor& p)
             getKeyMappings()->restoreFromXml(*elt);
         }
     } else {
-        settingsFile->getValueTree().appendChild(ValueTree("Keymap"), nullptr);
+        settingsFile->getValueTree().appendChild(ValueTree("KeyMap"), nullptr);
     }
 
     autoconnect.referTo(settingsFile->getPropertyAsValue("AutoConnect"));

--- a/Source/Utility/SettingsFile.h
+++ b/Source/Utility/SettingsFile.h
@@ -283,7 +283,7 @@ private:
     
     StringArray childTrees {
         "Paths",
-        "Keymap",
+        "KeyMap",  
         "ColourThemes",
         "SelectedThemes",
         "RecentlyOpened",


### PR DESCRIPTION
Fixed typo causing key mappings to init at startup