### PR TITLE
make sure we read init bool from patch

### DIFF
--- a/Source/Objects/IEMHelper.h
+++ b/Source/Objects/IEMHelper.h
@@ -35,6 +35,8 @@ public:
 
         sendSymbol = getSendSymbol();
         receiveSymbol = getReceiveSymbol();
+
+        initialise = getInit();
     }
 
     void initialiseParameters()


### PR DESCRIPTION
otherwise everything is set to not initialize the next time the patch is opened