### PR TITLE
ELSE docs improvements (A-B)

### DIFF
--- a/Resources/Documentation/ELSE/above.md
+++ b/Resources/Documentation/ELSE/above.md
@@ -1,12 +1,12 @@
 ---
 title: above
 
-description: Threshold detection
+description: threshold detection
 
 categories:
 - object
 
-pdcategory: Math
+pdcategory: Data Math
 
 arguments:
 - description: initial threshold value

--- a/Resources/Documentation/ELSE/above~.md
+++ b/Resources/Documentation/ELSE/above~.md
@@ -1,12 +1,12 @@
 ---
 title: above~
 
-description: Threshold detection
+description: threshold detection
 
 categories:
  - object
 
-pdcategory: Audio Math
+pdcategory: Signal Math
 
 arguments:
 - description: initial threshold value

--- a/Resources/Documentation/ELSE/add.md
+++ b/Resources/Documentation/ELSE/add.md
@@ -1,12 +1,12 @@
 ---
 title: add
 
-description: Number accumulator
+description: number accumulator
 
 categories:
 - object
 
-pdcategory: Math
+pdcategory: Data Math
 
 arguments:
 - description: starting sum

--- a/Resources/Documentation/ELSE/add~.md
+++ b/Resources/Documentation/ELSE/add~.md
@@ -1,12 +1,12 @@
 ---
 title: add~
 
-description: Signal accumulator
+description: signal accumulator
 
 categories:
  - object
 
-pdcategory: General
+pdcategory: Signal Math
 
 arguments:
 - type: float

--- a/Resources/Documentation/ELSE/adsr~.md
+++ b/Resources/Documentation/ELSE/adsr~.md
@@ -1,12 +1,12 @@
 ---
 title: adsr~
 
-description: Attack/Decay/Sustain/Release gated envelope
+description: attack/decay/sustain/release gated envelope
 
 categories:
  - object
 
-pdcategory: General
+pdcategory: Envelopes and LFOs
 
 arguments:
   1st:

--- a/Resources/Documentation/ELSE/allpass.2nd~.md
+++ b/Resources/Documentation/ELSE/allpass.2nd~.md
@@ -1,12 +1,12 @@
 ---
 title: allpass.2nd~
 
-description: Allpass filter
+description: allpass filter
 
 categories:
  - object
 
-pdcategory: General
+pdcategory: Filters
 
 arguments:
   1st:

--- a/Resources/Documentation/ELSE/allpass.filt~.md
+++ b/Resources/Documentation/ELSE/allpass.filt~.md
@@ -1,12 +1,12 @@
 ---
 title: allpass.filt~
 
-description: Allpass filter
+description: allpass filter
 
 categories:
 - object
 
-pdcategory: Audio Filters
+pdcategory: Filters
 
 arguments:
   1st:

--- a/Resources/Documentation/ELSE/allpass.rev~.md
+++ b/Resources/Documentation/ELSE/allpass.rev~.md
@@ -1,23 +1,20 @@
 ---
 title: allpass.rev~
 
-description: Allpass reverberator
+description: allpass reverberator
 
 categories:
  - object
 
-pdcategory: Audio Filters, Audio Delays, General Audio Manipulation
+pdcategory: Filters, Effects
 
 arguments:
-  1st:
   - type: float
     description: maximum and initial delay time in ms
     default: 0
-  2nd:
   - type: float
     description: decay time in ms
     default: 0
-  3rd:
   - type: float
     description: non-0 sets to gain mode
     default: 0

--- a/Resources/Documentation/ELSE/amean.md
+++ b/Resources/Documentation/ELSE/amean.md
@@ -1,12 +1,12 @@
 ---
 title: amean
 
-description: Generate list with arithmetic means
+description: generate list with arithmetic means
 
 categories:
 - object
 
-pdcategory: Math
+pdcategory: Data Math
 
 arguments:
   1st:

--- a/Resources/Documentation/ELSE/any2symbol.md
+++ b/Resources/Documentation/ELSE/any2symbol.md
@@ -1,12 +1,12 @@
 ---
 title: any2symbol
 
-description: Convert anything to symbol
+description: convert anything to symbol
 
 categories:
 - object
 
-pdcategory: General
+pdcategory: Data Management
 
 arguments:
 

--- a/Resources/Documentation/ELSE/args.md
+++ b/Resources/Documentation/ELSE/args.md
@@ -1,12 +1,12 @@
 ---
 title: args
 
-description: Manage arguments
+description: manage arguments
 
 categories:
  - object
 
-pdcategory: General
+pdcategory: Data Management
 
 arguments:
   1st:

--- a/Resources/Documentation/ELSE/asr~.md
+++ b/Resources/Documentation/ELSE/asr~.md
@@ -1,19 +1,17 @@
 ---
 title: asr~
 
-description: Attack/Sustain/Release gated envelope
+description: attack/sustain/release gated envelope
 
 categories:
  - object
 
-pdcategory: General
+pdcategory: Envelopes and LFOs
 
 arguments:
-  1st:
   - type: float
     description: attack time in ms
     default: 0
-  2nd:
   - type: float
     description: release time in  ms
     default: 0

--- a/Resources/Documentation/ELSE/autofade2~.md
+++ b/Resources/Documentation/ELSE/autofade2~.md
@@ -1,27 +1,23 @@
 ---
 title: autofade2~
 
-description: Automatic fade-in/out
+description: automatic fade-in/out
 
 categories:
  - object
 
-pdcategory: General
+pdcategory: Effects
 
 arguments:
-  1st:
   - type: symbol
     description: (optional) fade types <quartic, sin, sqrt, lin, hann, lin, hannsin, linsin>
     default: quartic
-  2nd:
   - type: float
     description: fade in time in ms
     default: 0
-  3rd:
   - type: float
     description: fade out time in ms
     default: 0
-  4th:
   - type: float
     description: number of channels
     default: 1

--- a/Resources/Documentation/ELSE/autofade~.md
+++ b/Resources/Documentation/ELSE/autofade~.md
@@ -1,23 +1,20 @@
 ---
 title: autofade~
 
-description: Automatic fade-in/out
+description: automatic fade-in/out
 
 categories:
  - object
 
-pdcategory: General
+pdcategory: Effects
 
 arguments:
-  1st:
   - type: symbol
     description: (optional) fade types <quartic, sin, sqrt, lin, hann, lin, hannsin, linsin>
     default: quartic
-  2nd:
   - type: float
     description: fade in/out time in ms
     default: 0
-  3rd:
   - type: float
     description: number of channels
     default: 1

--- a/Resources/Documentation/ELSE/autotune.md
+++ b/Resources/Documentation/ELSE/autotune.md
@@ -1,12 +1,12 @@
 ---
 title: autotune
 
-description: Retune to a close scale step
+description: retune to a close scale step
 
 categories:
 - object
 
-pdcategory: Audio Filters, General Audio Manipulation
+pdcategory: Tuning
 
 arguments:
   - description: scale in cents

--- a/Resources/Documentation/ELSE/autotune2.md
+++ b/Resources/Documentation/ELSE/autotune2.md
@@ -1,12 +1,12 @@
 ---
 title: autotune2
 
-description: Retune to a close scale step
+description: retune to a close scale step
 
 categories:
 - object
 
-pdcategory: Audio Filters, General Audio Manipulation
+pdcategory: Tuning
 
 arguments:
 - description: scale in cents

--- a/Resources/Documentation/ELSE/avg.md
+++ b/Resources/Documentation/ELSE/avg.md
@@ -1,12 +1,12 @@
 ---
 title: avg
 
-description: Mean average
+description: mean average
 
 categories:
 - object
 
-pdcategory: Math
+pdcategory: Data Math
 
 arguments:
 

--- a/Resources/Documentation/ELSE/balance~.md
+++ b/Resources/Documentation/ELSE/balance~.md
@@ -1,12 +1,12 @@
 ---
 title: balance~
 
-description: Stereo balancer
+description: stereo balancer
 
 categories:
  - object
 
-pdcategory: General Audio Manipulation
+pdcategory: Effects
 
 arguments:
 - type: float

--- a/Resources/Documentation/ELSE/bandpass~.md
+++ b/Resources/Documentation/ELSE/bandpass~.md
@@ -6,14 +6,14 @@ description: bandpass resonant filter
 categories:
  - object
 
-pdcategory: Audio Filters
+pdcategory: Filters
 
 arguments:
 - type: float
   description: central frequency in Hz
   default: 0
 - type: float
-  description: resonanace, either in Q (default) or bandwidth
+  description: resonance, either in Q (default) or bandwidth
   default: 1
 
 flags:
@@ -50,3 +50,4 @@ draft: false
 ---
 
 [bandpass~] is a 2nd order bandpass resonant filter. Unlike [else/resonant~], it has a maximum and constant gain at 0dB.
+

--- a/Resources/Documentation/ELSE/bandstop~.md
+++ b/Resources/Documentation/ELSE/bandstop~.md
@@ -1,19 +1,17 @@
 ---
 title: bandstop~
 
-description: Band stop filter
+description: band stop filter
 
 categories:
  - object
 
-pdcategory: Audio Filters
+pdcategory: Filters
 
 arguments:
-  1st:
   - type: float
     description: central frequency in Hz
     default: 0
-  2nd:
   - type: float
     description: resonance, either in 'Q' (default) or 'bw'
     default: 1

--- a/Resources/Documentation/ELSE/bangdiv.md
+++ b/Resources/Documentation/ELSE/bangdiv.md
@@ -1,19 +1,17 @@
 ---
 title: bangdiv
 
-description: Bang divider
+description: bang divider
 
 categories:
 - object
 
-pdcategory: General
+pdcategory: Triggers and Clocks, Sequencing
 
 arguments:
-  1st:
   - description: divisor value
     type: float
     default: 1
-  2nd:
   - description: start count value
     type: float
     default: 0
@@ -29,7 +27,7 @@ inlets:
 outlets:
   1st:
   - type: bang
-    description: 1st bang count
+    description: first bang
   2nd:
   - type: bang
     description: subsequent bangs until divisor value is hit

--- a/Resources/Documentation/ELSE/batch.rec~.md
+++ b/Resources/Documentation/ELSE/batch.rec~.md
@@ -1,19 +1,17 @@
 ---
 title: batch.rec~
 
-description: Sound file batch record
+description: sound file batch record
 
 categories:
 - object
 
-pdcategory: General Audio Manipulation
+pdcategory: Buffers
 
 arguments:
-  1st:
   - description:  (optional) file name to save to
     type: symbol
     default: file.wav
-  2nd:
   - description: number of channels to record
     type: symbol
     default: 1, max 64
@@ -33,9 +31,6 @@ methods:
     description: starts recording for given amount of time in ms. If no float is given, the last set value is used
   - type: set <symbol>
     description: sets file name (no symbol opens dialog box)
-
-click:
-  - description: clicking on the object opens a dialog box to set a file to save to
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/batch.write~.md
+++ b/Resources/Documentation/ELSE/batch.write~.md
@@ -1,12 +1,12 @@
 ---
 title: batch.write~
 
-description: Table batch write
+description: table batch write
 
 categories:
 - object
 
-pdcategory: General Audio Manipulation
+pdcategory: Buffers
 
 arguments:
 - description: array name to write to

--- a/Resources/Documentation/ELSE/bend.in.md
+++ b/Resources/Documentation/ELSE/bend.in.md
@@ -6,12 +6,12 @@ description: MIDI pitch bend input
 categories:
  - object
 
-pdcategory: I/O, MIDI
+pdcategory: MIDI
 
 arguments:
 - type: float
   description: sets channel number
-  default: default=0 - OMNI
+  default: 0 - OMNI
 
 flags:
 - name: -raw

--- a/Resources/Documentation/ELSE/bend.out.md
+++ b/Resources/Documentation/ELSE/bend.out.md
@@ -6,7 +6,7 @@ description: MIDI pitch bend output
 categories:
  - object
 
-pdcategory: I/O, MIDI
+pdcategory: MIDI
 
 arguments:
 - type: float

--- a/Resources/Documentation/ELSE/bicoeff.md
+++ b/Resources/Documentation/ELSE/bicoeff.md
@@ -1,15 +1,14 @@
 ---
 title: bicoeff
 
-description: Biquad filter coefficient generator GUI
+description: biquad filter coefficient generator GUI
 
 categories:
  - object
 
-pdcategory: Audio Math
+pdcategory: Filters
 
-arguments: (none)
-
+arguments:
 inlets:
   1st:
   - type: anything
@@ -22,11 +21,9 @@ outlets:
 
 flags:
   - name: -dim <f,f>
-    description: width, height 
-    default: 450, 150
+    description: width, height (default: 450, 150)
   - name: -type <fsymbol>
-    description: filter type
-    default: eq
+    description: filter type (default: eq)
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/bicoeff2.md
+++ b/Resources/Documentation/ELSE/bicoeff2.md
@@ -1,24 +1,20 @@
 ---
 title: bicoeff2
 
-description: Biquad coefficient generator
+description: biquad coefficient generator
 
 categories:
  - object
 
-pdcategory: Audio Math
+pdcategory: Filters
 
 arguments:
-  1st:
   - type: symbol
     description: (optional) sets type <hipass/etc>, (default='off')
-  2nd:
   - type: float
     description: sets cutoff/center frequency (default=0)
-  3rd:
   - type: float
     description: sets Q/slope (default=1)
-  4th:
   - type: float
     description: sets gain in db (default=0)
 

--- a/Resources/Documentation/ELSE/bin.shift~.md
+++ b/Resources/Documentation/ELSE/bin.shift~.md
@@ -1,19 +1,17 @@
 ---
 title: bin.shift~
 
-description: Shift bins
+description: shift bins
 
 categories:
 - object
 
-pdcategory: General Audio Manipulation
+pdcategory: Effects
 
 arguments:
-  1st:
   - description: sets shift number
     type: float
     default: 0
-  2nd:
   - description: non-zero sets to wrap mode
     type: float
     default: 0

--- a/Resources/Documentation/ELSE/biplot.md
+++ b/Resources/Documentation/ELSE/biplot.md
@@ -1,15 +1,14 @@
 ---
 title: biplot
 
-description: Biquad plot
+description: biquad plot
 
 categories:
 - object
 
-pdcategory: Audio filters, Analysis
+pdcategory: Filters, Analysis
 
 arguments:
-
 inlets:
   1st:
   - type: list

--- a/Resources/Documentation/ELSE/biquads~.md
+++ b/Resources/Documentation/ELSE/biquads~.md
@@ -1,12 +1,12 @@
 ---
 title: biquads~
 
-description: Biquad Series
+description: biquad Series
 
 categories:
  - object
 
-pdcategory: Audio Filters
+pdcategory: Filters
 
 inlets:
   1st:

--- a/Resources/Documentation/ELSE/bitnormal~.md
+++ b/Resources/Documentation/ELSE/bitnormal~.md
@@ -1,15 +1,14 @@
 ---
 title: bitnormal~
 
-description: Biquad Series
+description: biquad Series
 
 categories:
  - object
 
-pdcategory: Audio Math
+pdcategory: Signal Math, Filters
 
-arguments: (none)
-
+arguments:
 inlets:
   1st:
   - type: signal

--- a/Resources/Documentation/ELSE/bl.imp2~.md
+++ b/Resources/Documentation/ELSE/bl.imp2~.md
@@ -1,41 +1,23 @@
 ---
 title: bl.imp2~
 
-description: Bandlimited two-sided impulse oscillator
+description: bandlimited two-sided impulse oscillator
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
   1st:
   - type: float
     description: frequency in Hz
     default: 0
-  2nd:
-  - description:
-    type: float
-    default: .5
-  3rd:
-  - description: initial phase offset (0 to 1)
-    type: float
-    default: 0
 
 inlets:
   1st:
   - type: float/signal
     description: frequency in Hz
-  2nd:
-  - type: float/signal
-    description: pulse width (from 0 to 1)
-  3rd:
-  - type: float/signal
-    description: phase sync (resets internal phase)
-  4th:
-  - type: float/signal
-    description: phase offset (modulation input)
-
 outlets:
   1st:
   - type: signal
@@ -46,4 +28,3 @@ draft: false
 
 [bl.imp2~] is a two sided impulse oscillator like [else/imp2~], but it is bandlimited with the upsampling/filtering technique. This makes the object quite inefficient CPU wise, but is an easy way to implement a bandlimited oscillator. 
 
-TODO: Because this is an abstraction and Pd is still limited in the way it handles it, this object does not have any arguments.

--- a/Resources/Documentation/ELSE/bl.imp~.md
+++ b/Resources/Documentation/ELSE/bl.imp~.md
@@ -1,20 +1,16 @@
 ---
 title: bl.imp~
 
-description: Bandlimited impulse oscillator
+description: bandlimited impulse oscillator
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
   1st:
   - description: frequency in Hz
-    type: float
-    default: 0
-  2nd:
-  - description: initial phase offset
     type: float
     default: 0
 
@@ -22,12 +18,6 @@ inlets:
   1st:
   - type: float/signal
     description: frequency in Hz
-  2nd:
-  - type: float/signal
-    description: phase sync (resets internal phase)
-  3rd:
-  - type: float/signal
-    description: initial phase offset (modulation input)
 
 outlets:
   1st:

--- a/Resources/Documentation/ELSE/bl.osc~.md
+++ b/Resources/Documentation/ELSE/bl.osc~.md
@@ -1,12 +1,12 @@
 ---
 title: bl.osc~
 
-description: Bandlimited oscillator
+description: bandlimited oscillator
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
   - type: symbol
@@ -28,7 +28,7 @@ inlets:
     description: frequency in Hz
   2nd:
   - type: float/signal
-    description: phase sync (ressets internal phase)
+    description: phase sync (resets internal phase)
   3rd:
   - type: float/signal
     description: phase offset (modulation input)

--- a/Resources/Documentation/ELSE/bl.saw2~.md
+++ b/Resources/Documentation/ELSE/bl.saw2~.md
@@ -1,19 +1,17 @@
 ---
 title: bl.saw2~
 
-description: Bandlimited sawtooth oscillator
+description: bandlimited sawtooth oscillator
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
-  1st:
   - description:  frequency in Hz
     type: float
     default: 0
-  2nd:
   - description: initial phase offset
     type: float
     default: 0

--- a/Resources/Documentation/ELSE/bl.saw~.md
+++ b/Resources/Documentation/ELSE/bl.saw~.md
@@ -1,19 +1,17 @@
 ---
 title: bl.saw~
 
-description: Bandlimited sawtooth oscillator
+description: bandlimited sawtooth oscillator
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
-  1st:
   - description:  frequency in Hz
     type: float
     default: 0
-  2nd:
   - description: initial phase offset
     type: float
     default: 0

--- a/Resources/Documentation/ELSE/bl.square~.md
+++ b/Resources/Documentation/ELSE/bl.square~.md
@@ -1,23 +1,20 @@
 ---
 title: bl.square~
 
-description: Bandlimited square oscillator
+description: bandlimited square oscillator
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
-  1st:
   - description:  frequency in Hz
     type: float
     default: 0
-  2nd:
   - description:  initial pulse width
     type: float
     default: 0.5
-  3rd:
   - description: initial phase offset 
     type: float
     default: 0

--- a/Resources/Documentation/ELSE/bl.tri~.md
+++ b/Resources/Documentation/ELSE/bl.tri~.md
@@ -1,19 +1,17 @@
 ---
 title: bl.tri~
 
-description: Bandlimited triangular oscillator
+description: bandlimited triangular oscillator
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
-1st:
 - description: frequency in Hz
   type: float
   default: 0
-2nd:
 - description: initial phase offset
   type: float
   default: 0

--- a/Resources/Documentation/ELSE/bl.vsaw~.md
+++ b/Resources/Documentation/ELSE/bl.vsaw~.md
@@ -1,23 +1,20 @@
 ---
 title: bl.vsaw~
 
-description: Bandlimited sawtooth-triangular oscillator
+description: bandlimited sawtooth-triangular oscillator
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
-  1st:
   - description: frequency in Hz
     type: float
     default: 0
-  2nd:
   - description: initial width
     type: float
     default: 0
-  3rd:
   - description: initial phase offset
     type: float
     default: 0

--- a/Resources/Documentation/ELSE/bl.wavetable~.md
+++ b/Resources/Documentation/ELSE/bl.wavetable~.md
@@ -1,23 +1,20 @@
 ---
 title: bl.wavetable~
 
-description: Bandlimited wavetable oscillator
+description: bandlimited wavetable oscillator
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
-  1st:
   - description: array name (required)
     type: symbol
     default: none
-  2nd:
   - description: sets frequency in Hz
     type: float
     default: 0
-  3rd:
   - description: sets phase offset
     type: float
     default: 0

--- a/Resources/Documentation/ELSE/blip~.md
+++ b/Resources/Documentation/ELSE/blip~.md
@@ -1,12 +1,12 @@
 ---
 title: blip~
 
-description: Bandlimited cosine oscillator  
+description: bandlimited cosine oscillator  
 
 categories:
 - object
 
-pdcategory: Audio Oscillators and Tables
+pdcategory: Signal Generators
 
 arguments:
 - type: float
@@ -31,7 +31,7 @@ inlets:
     description: impulses reset phase
   3rd:
   - type: float/signal
-    description: phase modulationa input
+    description: phase modulation input
   4th:
     - type: float/signal
       description: spectral multiplier

--- a/Resources/Documentation/ELSE/blocksize~.md
+++ b/Resources/Documentation/ELSE/blocksize~.md
@@ -1,15 +1,14 @@
 ---
 title: blocksize~
 
-description: Get block size
+description: get block size
 
 categories:
  - object
 
-pdcategory: Accessing Data
+pdcategory: Data Management
 
-arguments: none
-
+arguments:
 inlets:
   1st:
   - type: bang

--- a/Resources/Documentation/ELSE/bpbank~.md
+++ b/Resources/Documentation/ELSE/bpbank~.md
@@ -1,19 +1,17 @@
 ---
 title: bpbank~
 
-description: Bank of bandpass filters
+description: bank of bandpass filters
 
 categories:
 - object
 
-pdcategory: Audio Filters
+pdcategory: Filters
 
 arguments:
-  1st:
   - description: number of bandpass filters
     type: float
     default: 1
-  2nd:
   - description: ramp time in ms
     type: float
     default: 10
@@ -34,7 +32,7 @@ flags:
 - name: -amp <list>
   description: sets list of amplitudes for all filters
 - name: -q <list>
-  description: sets list of resonsance (Q) for all filters
+  description: sets list of resonance (Q) for all filters
 - name: -ramp <list>
   description: sets list of ramp time for all filters
 - name: -rampall <float>

--- a/Resources/Documentation/ELSE/bpm.md
+++ b/Resources/Documentation/ELSE/bpm.md
@@ -1,15 +1,14 @@
 ---
 title: bpm
 
-description: Convert to/from bpm
+description: convert to/from bpm
 
 categories:
 - object
 
-pdcategory: Math
+pdcategory: Data Math, Triggers and Clocks, Sequencing
 
-arguments: none
-
+arguments:
 inlets:
   1st:
   - type: float

--- a/Resources/Documentation/ELSE/break.md
+++ b/Resources/Documentation/ELSE/break.md
@@ -1,12 +1,12 @@
 ---
 title: break
 
-description: Break lists
+description: break lists
 
 categories:
  - object
 
-pdcategory: General
+pdcategory: Data Management
 
 arguments:
 - type: symbol

--- a/Resources/Documentation/ELSE/brickwall~.md
+++ b/Resources/Documentation/ELSE/brickwall~.md
@@ -1,12 +1,12 @@
 ---
 title: brickwall~
 
-description: Brickwall filter
+description: brickwall filter
 
 categories:
 - object
 
-pdcategory: Audio Filters
+pdcategory: Filters
 
 arguments:
 - description: cutoff in Hz

--- a/Resources/Documentation/ELSE/brown.md
+++ b/Resources/Documentation/ELSE/brown.md
@@ -6,7 +6,7 @@ description: Brownian motion
 categories:
  - object
 
-pdcategory: Noise
+pdcategory: Noise, Data Math
 
 arguments:
 - type: float

--- a/Resources/Documentation/ELSE/brown~.md
+++ b/Resources/Documentation/ELSE/brown~.md
@@ -1,12 +1,12 @@
 ---
 title: brown~
 
-description: Brown noise generator
+description: brown noise generator
 
 categories:
  - object
 
-pdcategory: Noise
+pdcategory: Noise, Signal Generators, Signal Math
 
 arguments:
 - type: float

--- a/Resources/Documentation/ELSE/buffer.md
+++ b/Resources/Documentation/ELSE/buffer.md
@@ -1,12 +1,12 @@
 ---
 title: buffer
 
-description: Get/set array buffer
+description: get/set array buffer
 
 categories:
  - object
 
-pdcategory: Array
+pdcategory: Arrays and Tables, Buffers, Data Management
 
 arguments:
 - type: symbol

--- a/Resources/Documentation/ELSE/button.md
+++ b/Resources/Documentation/ELSE/button.md
@@ -2,15 +2,14 @@
 
 title: button
 
-description: Button GUI
+description: button GUI
 
 categories:
  - object
 
-pdcategory: General
+pdcategory: GUI
 
-arguments: none
-
+arguments:
 inlets:
   1st:
   - type: dim <f, f>


### PR DESCRIPTION
lowercase descriptions, removed argument counts (they were showing in ref), spellchecking (actually caught 3 typos! not bad!), and categories..

oh yeah, those deletions on bl.imp(2)~ are according to the new help files, i'll make sure to pull those from else

resonanace lol i'm too dyslexic to notice that on my own