### PR TITLE
allow the "set" symbol to set radio index

### DIFF
--- a/Source/Objects/RadioObject.h
+++ b/Source/Objects/RadioObject.h
@@ -93,7 +93,7 @@ public:
 
     void receiveObjectMessage(String const& symbol, std::vector<pd::Atom>& atoms) override
     {
-        if (symbol == "float") {
+        if (symbol == "float" || symbol == "set") {
             selected = atoms[0].getFloat();
             repaint();
         }


### PR DESCRIPTION
As per `radio-help.pd`: The 'set' message only sets the value without output.