### PR TITLE
Component Constrainer Stage 1

### DIFF
--- a/Libraries/ELSE/Source/keyboard.c
+++ b/Libraries/ELSE/Source/keyboard.c
@@ -814,7 +814,7 @@ void * keyboard_new(t_symbol *s, int ac, t_atom* av){
     x->x_space = (init_space < 7) ? 7 : init_space; // key width
     x->x_height = (init_height < 10) ? 10 : init_height;
     x->x_octaves = init_8ves < 1 ? 1 : init_8ves > 10 ? 10 : init_8ves;
-    x->x_low_c = init_low_c < 0 ? 0 : init_low_c > 8 ? 8 : init_low_c;
+    x->x_low_c = init_low_c < -1 ? -1 : init_low_c > 9 ? 9 : init_low_c;
     x->x_norm = vel < 0 ? 0 : vel > 127 ? 127 : vel;
     x->x_toggle_mode = (tgl != 0);
     x->x_width = ((int)(x->x_space)) * 7 * (int)x->x_octaves;

--- a/Source/Object.h
+++ b/Source/Object.h
@@ -13,6 +13,7 @@ extern "C" {
 }
 
 #include "ObjectGrid.h"
+#include "Utility/ObjectComponentBoundsConstrainer.h"
 #include "Iolet.h"
 #include "Objects/ObjectBase.h"
 
@@ -20,6 +21,7 @@ class Canvas;
 class Object : public Component
     , public Value::Listener
     , public Timer
+    , public ObjectComponentBoundsConstrainer
     , private TextEditor::Listener {
 public:
     Object(Canvas* parent, String const& name = "", Point<int> position = { 100, 100 });
@@ -66,6 +68,8 @@ public:
     void textEditorTextChanged(TextEditor& ed) override;
 
     bool hitTest(int x, int y) override;
+
+    bool validResizeZone = false;
 
     Array<Rectangle<float>> getCorners() const;
 

--- a/Source/Objects/ArrayObject.h
+++ b/Source/Objects/ArrayObject.h
@@ -140,6 +140,8 @@ public:
 
         setInterceptsMouseClicks(true, false);
         setOpaque(false);
+
+        object->setMinimumSize(100 - Object::doubleMargin, 40 - Object::doubleMargin);
     }
 
     void setArray(PdArray& graph)
@@ -538,17 +540,6 @@ public:
         pd->getCallbackLock()->exit();
 
         object->setObjectBounds(bounds);
-    }
-
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(100, maxSize, object->getWidth());
-        int h = jlimit(40, maxSize, object->getHeight());
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
-        }
     }
 
     ObjectParameters getParameters() override

--- a/Source/Objects/BangObject.h
+++ b/Source/Objects/BangObject.h
@@ -47,14 +47,6 @@ public:
         iemHelper.applyBounds();
     }
 
-    void checkBounds() override
-    {
-        // Fix aspect ratio and apply limits
-        int size = jlimit(30, maxSize, object->getWidth());
-        if (size != object->getHeight() || size != object->getWidth()) {
-            object->setSize(size, size);
-        }
-    }
     void toggleObject(Point<int> position) override
     {
         if (!alreadyBanged) {

--- a/Source/Objects/BangObject.h
+++ b/Source/Objects/BangObject.h
@@ -23,6 +23,8 @@ public:
         auto* bng = static_cast<t_bng*>(ptr);
         bangInterrupt = bng->x_flashtime_break;
         bangHold = bng->x_flashtime_hold;
+
+        parent->setFixedAspectRatio(1);
     }
 
     void initialiseParameters() override

--- a/Source/Objects/ButtonObject.h
+++ b/Source/Objects/ButtonObject.h
@@ -40,6 +40,7 @@ public:
     ButtonObject(void* obj, Object* parent)
         : ObjectBase(obj, parent)
     {
+        parent->setFixedAspectRatio(1);
     }
 
     void checkBounds() override

--- a/Source/Objects/ButtonObject.h
+++ b/Source/Objects/ButtonObject.h
@@ -43,15 +43,6 @@ public:
         parent->setFixedAspectRatio(1);
     }
 
-    void checkBounds() override
-    {
-        // Fix aspect ratio and apply limits
-        int size = jlimit(30, maxSize, object->getWidth());
-        if (size != object->getHeight() || size != object->getWidth()) {
-            object->setSize(size, size);
-        }
-    }
-
     void initialiseParameters() override
     {
         auto* button = static_cast<t_fake_button*>(ptr);

--- a/Source/Objects/CanvasObject.h
+++ b/Source/Objects/CanvasObject.h
@@ -69,17 +69,6 @@ public:
         static_cast<t_my_canvas*>(ptr)->x_vis_h = getHeight() - 1;
     }
 
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(20, maxSize, object->getWidth());
-        int h = jlimit(20, maxSize, object->getHeight());
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
-        }
-    }
-
     void paint(Graphics& g) override
     {
         g.fillAll(Colour::fromString(iemHelper.secondaryColour.toString()));

--- a/Source/Objects/FloatAtomObject.h
+++ b/Source/Objects/FloatAtomObject.h
@@ -136,17 +136,6 @@ public:
         object->setObjectBounds(bounds);
     }
 
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(30, maxSize, object->getWidth());
-        int h = atomHelper.getAtomHeight() + Object::doubleMargin;
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
-        }
-    }
-
     void applyBounds() override
     {
         auto b = object->getObjectBounds();

--- a/Source/Objects/FunctionObject.h
+++ b/Source/Objects/FunctionObject.h
@@ -101,17 +101,6 @@ public:
         static_cast<t_my_canvas*>(ptr)->x_vis_h = getHeight();
     }
 
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(20, maxSize, object->getWidth());
-        int h = jlimit(20, maxSize, object->getHeight());
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
-        }
-    }
-
     Array<Point<float>> getRealPoints()
     {
         auto realPoints = Array<Point<float>>();

--- a/Source/Objects/GraphOnParent.h
+++ b/Source/Objects/GraphOnParent.h
@@ -91,17 +91,6 @@ public:
         return false;
     }
 
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(25, maxSize, object->getWidth());
-        int h = jlimit(25, maxSize, object->getHeight());
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
-        }
-    }
-
     void updateBounds() override
     {
         pd->getCallbackLock()->enter();

--- a/Source/Objects/IEMHelper.h
+++ b/Source/Objects/IEMHelper.h
@@ -213,14 +213,21 @@ public:
         object->setObjectBounds(bounds);
     }
 
-    void applyBounds()
+    void applyBounds(bool isVertical = true)
     {
         auto b = object->getObjectBounds();
 
         iemgui->x_obj.te_xpix = b.getX();
         iemgui->x_obj.te_ypix = b.getY();
-        iemgui->x_w = b.getWidth();
-        iemgui->x_h = b.getHeight();
+
+        // this is needed for RadioObject due to both vertical & horizontal being saved in same values
+        if (isVertical) {
+            iemgui->x_w = b.getWidth();
+            iemgui->x_h = b.getHeight();
+        } else {
+            iemgui->x_w = b.getHeight();
+            iemgui->x_h = b.getHeight();
+        }
     }
 
     void updateLabel(std::unique_ptr<ObjectLabel>& label)

--- a/Source/Objects/ListObject.h
+++ b/Source/Objects/ListObject.h
@@ -109,17 +109,6 @@ public:
         object->setObjectBounds(bounds);
     }
 
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(30, maxSize, object->getWidth());
-        int h = atomHelper.getAtomHeight() + Object::doubleMargin;
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
-        }
-    }
-
     ObjectParameters getParameters() override
     {
         return atomHelper.getParameters();

--- a/Source/Objects/NumberObject.h
+++ b/Source/Objects/NumberObject.h
@@ -95,16 +95,6 @@ public:
         object->setObjectBounds(bounds);
     }
 
-    void checkBounds() override
-    {
-        int const widthIncrement = 9;
-        int width = jlimit(27, maxSize, (getWidth() / widthIncrement) * widthIncrement);
-        int height = jlimit(18, maxSize, getHeight());
-        if (getWidth() != width || getHeight() != height) {
-            object->setSize(width + Object::doubleMargin, height + Object::doubleMargin);
-        }
-    }
-
     void applyBounds() override
     {
         auto b = object->getObjectBounds();

--- a/Source/Objects/PictureObject.h
+++ b/Source/Objects/PictureObject.h
@@ -110,17 +110,6 @@ public:
         object->setObjectBounds(bounds);
     }
 
-    void checkBounds() override
-    {
-        auto* pic = static_cast<t_pic*>(ptr);
-
-        if (!imageFile.existsAsFile()) {
-            object->setSize(50, 50);
-        } else if (pic->x_height != img.getHeight() || pic->x_width != img.getWidth()) {
-            object->setSize(img.getWidth(), img.getHeight());
-        }
-    }
-
     void receiveObjectMessage(String const& symbol, std::vector<pd::Atom>& atoms) override
     {
         if (symbol == "open" && atoms.size() >= 1) {

--- a/Source/Objects/RadioObject.h
+++ b/Source/Objects/RadioObject.h
@@ -28,7 +28,7 @@ public:
 
         selected = getValue();
 
-        numItems = static_cast<int>(max.getValue());
+        valueChanged(max);
 
         if (selected > static_cast<int>(max.getValue())) {
             selected = std::min<int>(static_cast<int>(max.getValue()) - 1, selected);
@@ -43,20 +43,6 @@ public:
     void initialiseParameters() override
     {
         iemHelper.initialiseParameters();
-    }
-
-    void resized() override
-    {
-        int size = (isVertical ? getWidth() : getHeight());
-        int minSize = 12;
-        size = std::max(size, minSize);
-
-        // Fix aspect ratio
-        if (isVertical) {
-            object->setSize(std::max(object->getWidth(), minSize + Object::doubleMargin), size * numItems + Object::doubleMargin);
-        } else {
-            object->setSize(size * numItems + Object::doubleMargin, std::max(object->getHeight(), minSize + Object::doubleMargin));
-        }
     }
 
     void applyBounds() override

--- a/Source/Objects/RadioObject.h
+++ b/Source/Objects/RadioObject.h
@@ -3,6 +3,7 @@
  // For information on usage and redistribution, and for a DISCLAIMER OF ALL
  // WARRANTIES, see the file, "LICENSE.txt," in this distribution.
  */
+#include <JuceHeader.h>
 
 class RadioObject final : public ObjectBase {
 
@@ -46,20 +47,12 @@ public:
     }
 
     void applyBounds() override
-    {        
-        auto* radio = static_cast<t_radio*>(ptr);
-
-        if (isVertical) {
-            radio->x_gui.x_w = getWidth();
-            radio->x_gui.x_h = getHeight();
-        } else {
-            radio->x_gui.x_w = getHeight();
-            radio->x_gui.x_h = getWidth();
-        }
+    {
+        iemHelper.applyBounds();
     }
 
     void toggleObject(Point<int> position) override
-    {
+    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
         if (alreadyToggled) {
             alreadyToggled = false;
         }
@@ -94,12 +87,12 @@ public:
     }
 
     void untoggleObject() override
-    {
+    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
         alreadyToggled = false;
     }
 
     void mouseDown(MouseEvent const& e) override
-    {
+    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
         float pos = isVertical ? e.y : e.x;
         float div = isVertical ? getHeight() : getWidth();
 
@@ -114,12 +107,13 @@ public:
     }
 
     float getValue()
-    {
+    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
         return static_cast<t_radio*>(ptr)->x_on;
     }
 
     void updateBounds() override
-    {
+    {        
+        printf("calling: %s\n", __PRETTY_FUNCTION__);
         pd->getCallbackLock()->enter();
 
         int x = 0, y = 0, w = 0, h = 0;
@@ -129,9 +123,9 @@ public:
         auto* radio = static_cast<t_radio*>(ptr);
 
         if (isVertical) {
-            bounds.setSize(radio->x_gui.x_w, radio->x_gui.x_h);
+            bounds.setSize(radio->x_gui.x_w, radio->x_gui.x_w * numItems);
         } else {
-            bounds.setSize(radio->x_gui.x_h, radio->x_gui.x_w);
+            bounds.setSize(radio->x_gui.x_h * numItems , radio->x_gui.x_h);
         }
 
         pd->getCallbackLock()->exit();
@@ -144,7 +138,7 @@ public:
         g.setColour(iemHelper.getBackgroundColour());
         g.fillRoundedRectangle(getLocalBounds().toFloat().reduced(0.5f), PlugDataLook::objectCornerRadius);
 
-        int size = (isVertical ? getWidth() : getHeight());
+        int size = (isVertical ? getHeight() / numItems : getHeight());
         //int minSize = 12;
         //size = std::max(size, minSize);
 
@@ -178,7 +172,7 @@ public:
     }
 
     ObjectParameters getParameters() override
-    {
+    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
         ObjectParameters allParameters = { { "Options", tInt, cGeneral, &max, {} } };
 
         auto iemParameters = iemHelper.getParameters();
@@ -188,7 +182,7 @@ public:
     }
 
     void updateAspectRatio() 
-    {
+    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
         float verticalLength = ((object->getWidth() - Object::doubleMargin) * numItems) + Object::doubleMargin;
         float horizontalLength = ((object->getHeight() - Object::doubleMargin) * numItems) + Object::doubleMargin;
 
@@ -197,27 +191,30 @@ public:
         } else {
             object->setSize(horizontalLength, object->getHeight());
         }
-        object->setFixedAspectRatio(isVertical ? 1.0f /  numItems : numItems / 1.0f);
+        object->setFixedAspectRatio(isVertical ? 1.0f /  numItems : static_cast<float>(numItems) / 1.0f);
     }
 
     void valueChanged(Value& value) override
-    {
+    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
         if (value.refersToSameSourceAs(max)) {
-            numItems = static_cast<int>(max.getValue());
-            updateAspectRatio();
-            setMaximum(limitValueMin(value, 1));
+            if (static_cast<int>(max.getValue()) != numItems) {
+                limitValueMin(value, 1);
+                numItems = static_cast<int>(max.getValue());
+                updateAspectRatio();
+                setMaximum(numItems);
+            }
         } else {
             iemHelper.valueChanged(value);
         }
     }
 
     float getMaximum()
-    {
+    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
         return static_cast<t_radio*>(ptr)->x_number;
     }
 
     void setMaximum(float maxValue)
-    {
+    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
         if (selected >= maxValue) {
             selected = maxValue - 1;
         }

--- a/Source/Objects/RadioObject.h
+++ b/Source/Objects/RadioObject.h
@@ -34,6 +34,7 @@ public:
         if (selected > static_cast<int>(max.getValue())) {
             selected = std::min<int>(static_cast<int>(max.getValue()) - 1, selected);
         }
+        object->setMinimumSize(15, 15);
     }
 
     void updateLabel() override
@@ -48,11 +49,11 @@ public:
 
     void applyBounds() override
     {
-        iemHelper.applyBounds();
+        iemHelper.applyBounds(isVertical);
     }
 
     void toggleObject(Point<int> position) override
-    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         if (alreadyToggled) {
             alreadyToggled = false;
         }
@@ -87,12 +88,12 @@ public:
     }
 
     void untoggleObject() override
-    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         alreadyToggled = false;
     }
 
     void mouseDown(MouseEvent const& e) override
-    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         float pos = isVertical ? e.y : e.x;
         float div = isVertical ? getHeight() : getWidth();
 
@@ -107,13 +108,12 @@ public:
     }
 
     float getValue()
-    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         return static_cast<t_radio*>(ptr)->x_on;
     }
 
     void updateBounds() override
-    {        
-        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         pd->getCallbackLock()->enter();
 
         int x = 0, y = 0, w = 0, h = 0;
@@ -172,7 +172,7 @@ public:
     }
 
     ObjectParameters getParameters() override
-    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         ObjectParameters allParameters = { { "Options", tInt, cGeneral, &max, {} } };
 
         auto iemParameters = iemHelper.getParameters();
@@ -182,7 +182,7 @@ public:
     }
 
     void updateAspectRatio() 
-    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         float verticalLength = ((object->getWidth() - Object::doubleMargin) * numItems) + Object::doubleMargin;
         float horizontalLength = ((object->getHeight() - Object::doubleMargin) * numItems) + Object::doubleMargin;
 
@@ -195,7 +195,7 @@ public:
     }
 
     void valueChanged(Value& value) override
-    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         if (value.refersToSameSourceAs(max)) {
             if (static_cast<int>(max.getValue()) != numItems) {
                 limitValueMin(value, 1);
@@ -209,12 +209,12 @@ public:
     }
 
     float getMaximum()
-    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         return static_cast<t_radio*>(ptr)->x_number;
     }
 
     void setMaximum(float maxValue)
-    {        printf("calling: %s\n", __PRETTY_FUNCTION__);
+    {
         if (selected >= maxValue) {
             selected = maxValue - 1;
         }

--- a/Source/Objects/ScopeObject.h
+++ b/Source/Objects/ScopeObject.h
@@ -159,17 +159,6 @@ public:
     {
     }
 
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(20, maxSize, object->getWidth());
-        int h = jlimit(20, maxSize, object->getHeight());
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
-        }
-    }
-
     void paint(Graphics& g) override
     {
         g.fillAll(Colour::fromString(secondaryColour.toString()));

--- a/Source/Objects/SliderObject.h
+++ b/Source/Objects/SliderObject.h
@@ -64,6 +64,12 @@ public:
         slider.onDragEnd = [this]() {
             stopEdition();
         };
+        if (isVertical) {
+            object->setMinimumSize(15, 30);
+        } else {
+            object->setMinimumSize(30, 15);
+        }
+
     }
 
     void updateLabel() override
@@ -120,17 +126,6 @@ public:
             slider.setSliderSnapsToMousePosition(!steady);
         } else {
             iemHelper.receiveObjectMessage(symbol, atoms);
-        }
-    }
-
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(isVertical ? 23 : 50, maxSize, object->getWidth());
-        int h = jlimit(isVertical ? 77 : 25, maxSize, object->getHeight());
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
         }
     }
 

--- a/Source/Objects/SymbolAtomObject.h
+++ b/Source/Objects/SymbolAtomObject.h
@@ -84,17 +84,6 @@ public:
         object->setObjectBounds(bounds);
     }
 
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(30, maxSize, object->getWidth());
-        int h = atomHelper.getAtomHeight() + Object::doubleMargin;
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
-        }
-    }
-
     void applyBounds() override
     {
         auto b = object->getObjectBounds();

--- a/Source/Objects/TextObject.h
+++ b/Source/Objects/TextObject.h
@@ -148,6 +148,7 @@ public:
 
         // To get enter/exit messages
         addMouseListener(object, false);
+        
     }
 
     virtual ~TextBase()

--- a/Source/Objects/TextObject.h
+++ b/Source/Objects/TextObject.h
@@ -138,6 +138,7 @@ protected:
     String objectText;
     int numLines = 1;
     bool isValid = true;
+    bool firstRun = true;
 
 public:
     TextBase(void* obj, Object* parent, bool valid = true)
@@ -232,7 +233,10 @@ public:
         numLines = newNumLines;
         
         if(newBounds != object->getObjectBounds()) {
-            //object->setObjectBounds(newBounds);
+            if (firstRun) {
+                object->setObjectBounds(newBounds);
+                firstRun = false;
+            }
             object->setMinimumHeight(newBounds.getHeight());
             object->setMaximumHeight(newBounds.getHeight());
         }

--- a/Source/Objects/TextObject.h
+++ b/Source/Objects/TextObject.h
@@ -148,7 +148,6 @@ public:
 
         // To get enter/exit messages
         addMouseListener(object, false);
-        
     }
 
     virtual ~TextBase()
@@ -231,15 +230,17 @@ public:
         auto newBounds = TextObjectHelper::recalculateTextObjectBounds(cnvPtr, ptr, objText, 15, newNumLines, true, std::max({ 1, object->numInputs, object->numOutputs }));
 
         numLines = newNumLines;
-
-        if (newBounds != object->getObjectBounds()) {
-            object->setObjectBounds(newBounds);
+        
+        if(newBounds != object->getObjectBounds()) {
+            //object->setObjectBounds(newBounds);
+            object->setMinimumHeight(newBounds.getHeight());
+            object->setMaximumHeight(newBounds.getHeight());
         }
 
         pd->getCallbackLock()->exit();
     }
 
-    void checkBounds() override
+    void checkBoundsLocal()
     {
         int fontWidth = glist_fontwidth(cnv->patch.getPointer());
         TextObjectHelper::setWidthInChars(ptr, getWidth() / fontWidth);
@@ -329,6 +330,7 @@ public:
         if (editor) {
             editor->setBounds(getLocalBounds());
         }
+        checkBoundsLocal();
     }
 
     /** Returns the currently-visible text editor, or nullptr if none is open. */

--- a/Source/Objects/ToggleObject.h
+++ b/Source/Objects/ToggleObject.h
@@ -19,6 +19,7 @@ public:
         , iemHelper(ptr, object, this)
     {
         value = getValue();
+        object->setFixedAspectRatio(1);
     }
 
     void updateLabel() override
@@ -99,15 +100,6 @@ public:
 
         // Make sure we don't re-toggle with an accidental drag
         alreadyToggled = true;
-    }
-
-    void checkBounds() override
-    {
-        // Fix aspect ratio and apply limits
-        int size = jlimit(30, maxSize, object->getWidth());
-        if (size != object->getHeight() || size != object->getWidth()) {
-            object->setSize(size, size);
-        }
     }
 
     ObjectParameters getParameters() override

--- a/Source/Objects/VUMeterObject.h
+++ b/Source/Objects/VUMeterObject.h
@@ -13,6 +13,7 @@ public:
         : ObjectBase(ptr, object)
         , iemHelper(ptr, object, this)
     {
+        object->setMinimumSize(20,40);
     }
 
     void updateLabel() override
@@ -43,17 +44,6 @@ public:
     void applyBounds() override
     {
         iemHelper.applyBounds();
-    }
-
-    void checkBounds() override
-    {
-        // Apply size limits
-        int w = jlimit(30, maxSize, object->getWidth());
-        int h = jlimit(80, maxSize, object->getHeight());
-
-        if (w != object->getWidth() || h != object->getHeight()) {
-            object->setSize(w, h);
-        }
     }
 
     void paint(Graphics& g) override

--- a/Source/Utility/ObjectComponentBoundsConstrainer.cpp
+++ b/Source/Utility/ObjectComponentBoundsConstrainer.cpp
@@ -1,0 +1,24 @@
+#include "ObjectComponentBoundsConstrainer.h"
+#include "Object.h"
+
+void ObjectComponentBoundsConstrainer::checkBounds (Rectangle<int>& bounds,
+                                                    const Rectangle<int>& old,
+                                                    const Rectangle<int>& limits,
+                                                    bool isStretchingTop,
+                                                    bool isStretchingLeft,
+                                                    bool isStretchingBottom,
+                                                    bool isStretchingRight)
+{
+    // we remove the margin from the resizing object
+    BorderSize<int> border(Object::margin);
+    border.subtractFrom(bounds);
+
+    // we also have to remove the margin from the old object, but don't alter the old object
+    ComponentBoundsConstrainer::checkBounds(bounds, border.subtractedFrom(old), limits, isStretchingTop, 
+                                                                                        isStretchingLeft, 
+                                                                                        isStretchingBottom, 
+                                                                                        isStretchingRight);
+
+    // put back the margins
+    border.addTo(bounds);
+}

--- a/Source/Utility/ObjectComponentBoundsConstrainer.h
+++ b/Source/Utility/ObjectComponentBoundsConstrainer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+class ObjectComponentBoundsConstrainer: public ComponentBoundsConstrainer
+{
+public:
+   /* 
+    * Custom version of checkBounds that takes into consideration
+    * the padding around plugdata node objects when resizing
+    * to allow the aspect ratio to be interpreted correctly.
+    * Otherwise resizing objects with an aspect ratio will
+    * resize the object size **including** margins, and not follow the 
+    * actual size of the visible object
+    */
+    void checkBounds (Rectangle<int>& bounds,
+                      const Rectangle<int>& old,
+                      const Rectangle<int>& limits,
+                      bool isStretchingTop,
+                      bool isStretchingLeft,
+                      bool isStretchingBottom,
+                      bool isStretchingRight) override;
+};


### PR DESCRIPTION
Component Constrainer allows Juce to take over resizing of objects on the canvas.
This means that all 4 corners of the objects can be used to resize, without changing position.
It also means that we set the min/max size of the component, and Juce will take care of the rest.

There are still issues with the following objects (that I am aware of):
* comment (resize doesn't reflow text)
* list box
* symbol box
* float box
* new message (resize doesn't reflow text)

Bugs:
* empty object (double click on canvas works, but menu item addition crashes plugdata)
* radio object can sometimes change position when zoom != 100% 