### PR TITLE
avoid duplicate mousepad output values

### DIFF
--- a/Source/Objects/MousePadObject.h
+++ b/Source/Objects/MousePadObject.h
@@ -54,9 +54,9 @@ public:
     {
         auto relativeEvent = e.getEventRelativeTo(this);
 
-        if (!getLocalBounds().contains(relativeEvent.getPosition()) || !isLocked() || !object->cnv->isShowing())
+        if (!getLocalBounds().contains(relativeEvent.getPosition()) || !isLocked() || !object->cnv->isShowing() || isPressed )
             return;
-
+		
         auto* x = static_cast<t_pad*>(ptr);
         t_atom at[3];
 
@@ -69,6 +69,8 @@ public:
         sys_unlock();
 
         isPressed = true;
+        
+       
     }
 
     void mouseDrag(MouseEvent const& e) override
@@ -91,7 +93,7 @@ public:
         SETFLOAT(at, x->x_x);
         SETFLOAT(at + 1, x->x_y);
 
-        lastPosition = { x->x_x, x->x_y };
+        lastPosition = { x->x_x, getHeight() - x->x_y };
 
         sys_lock();
         outlet_anything(x->x_obj.ob_outlet, &s_list, 2, at);
@@ -118,7 +120,7 @@ public:
         SETFLOAT(at, x->x_x);
         SETFLOAT(at + 1, x->x_y);
 
-        lastPosition = { x->x_x, x->x_y };
+        lastPosition = { x->x_x, getHeight() - x->x_y };
 
         sys_lock();
         outlet_anything(x->x_obj.ob_outlet, &s_list, 2, at);
@@ -127,7 +129,7 @@ public:
 
     void mouseUp(MouseEvent const& e) override
     {
-        if ((!getScreenBounds().contains(e.getMouseDownScreenPosition()) && !isPressed) || !isLocked())
+        if ((!getScreenBounds().contains(e.getMouseDownScreenPosition()) || !isPressed) || !isLocked())
             return;
 
         auto* x = static_cast<t_pad*>(ptr);
@@ -174,12 +176,8 @@ public:
 
     void receiveObjectMessage(String const& symbol, std::vector<pd::Atom>& atoms) override
     {
-        switch (objectMessageMapped[symbol]) {
-            case objectMessage::msg_color: {
-                repaint();
-                break;
-            }
-            default: break;
+        if (symbol == "color") {
+            repaint();
         }
     }
 };


### PR DESCRIPTION
Due to inverted Y axe, the test with lastPosition didn't work anymore in mouseDrag and mouseMove functions. 
I also changed the logic tests for mouseUp and mouseDown.

[ I have manually dropped the modified file on github website. Not sure it is the correct way to do :-)  ]