### PR TITLE
Fix aspect ratio min-size  &  ELSE keyboard

### DIFF
--- a/Libraries/ELSE/Source/keyboard.c
+++ b/Libraries/ELSE/Source/keyboard.c
@@ -813,7 +813,7 @@ void * keyboard_new(t_symbol *s, int ac, t_atom* av){
         pd_bind(&x->x_obj.ob_pd, x->x_receive);
     x->x_space = (init_space < 7) ? 7 : init_space; // key width
     x->x_height = (init_height < 10) ? 10 : init_height;
-    x->x_octaves = init_8ves < 1 ? 1 : init_8ves > 10 ? 10 : init_8ves;
+    x->x_octaves = init_8ves < 1 ? 1 : init_8ves > 11 ? 11 : init_8ves;
     x->x_low_c = init_low_c < -1 ? -1 : init_low_c > 9 ? 9 : init_low_c;
     x->x_norm = vel < 0 ? 0 : vel > 127 ? 127 : vel;
     x->x_toggle_mode = (tgl != 0);

--- a/Source/Objects/KeyboardObject.h
+++ b/Source/Objects/KeyboardObject.h
@@ -301,6 +301,7 @@ public:
 
         object->setSize(horizontalLength + Object::doubleMargin, object->getHeight());
         object->constrainer->setFixedAspectRatio(horizontalLength / static_cast<float>(object->getHeight() - Object::doubleMargin));
+        object->constrainer->setMinimumSize((15.0f / 5) * numWhiteKeys, 15);
     }
 
     void valueChanged(Value& value) override

--- a/Source/Objects/RadioObject.h
+++ b/Source/Objects/RadioObject.h
@@ -34,7 +34,6 @@ public:
         if (selected > static_cast<int>(max.getValue())) {
             selected = std::min<int>(static_cast<int>(max.getValue()) - 1, selected);
         }
-        object->constrainer->setMinimumSize(15, 15);
     }
 
     void updateLabel() override
@@ -200,8 +199,10 @@ public:
 
         if (isVertical) {
             object->setSize(object->getWidth(), verticalLength);
+            object->constrainer->setMinimumSize(15, 15 * numItems);
         } else {
             object->setSize(horizontalLength, object->getHeight());
+            object->constrainer->setMinimumSize(15 * numItems, 15);
         }
         object->constrainer->setFixedAspectRatio(isVertical ? 1.0f / numItems : static_cast<float>(numItems) / 1.0f);
     }


### PR DESCRIPTION
We need to set the min-size so the constrainer knows when it should stop changing size, so we need to calculate the min-size when geometry is updated (more keys added, or radio boxes)
This only effects objects that use an aspect ratio that is greater than 1.

Also fixed a small bug with ELSE keyboard not saving the octave count > 10 (we allow full size keyboard in Plugdata)