### PR TITLE
we no longer need to inform the canvas of mouse events on objects.

### DIFF
--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -82,7 +82,6 @@ void Object::initialise()
 {
     constrainer = std::make_unique<ObjectBoundsConstrainer>();
 
-    addMouseListener(cnv, true); // Receive mouse messages on canvas
     cnv->addAndMakeVisible(this);
 
     // Updates lock/unlock mode


### PR DESCRIPTION
this was causing numerous issues:

* Slowing down rendering, as sometimes it could trigger the whole canvas to repaint when it didn't need to
* In some cases the repainting became a feedback loop, triggering other canvas functions
