### PR TITLE
set new connection component to always on top & highlight

### DIFF
--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -130,6 +130,8 @@ public:
         iolet->addMouseListener(this, false);
         
         cnv->addAndMakeVisible(this);
+
+        setAlwaysOnTop(true);
     }
     
     ~ConnectionBeingCreated() {
@@ -172,7 +174,7 @@ public:
             jassertfalse; // shouldn't happen
             return;
         }
-        Connection::renderConnectionPath(g, (Canvas*)cnv, connectionPath, iolet->isSignal);
+        Connection::renderConnectionPath(g, (Canvas*)cnv, connectionPath, iolet->isSignal, true);
     }
     
     Iolet* getIolet() {


### PR DESCRIPTION
* When we make new connections we want them to always be on top of the canvas
* Highlight them for added visibility when working in dense compositions with many cables etc.
![highlight](https://user-images.githubusercontent.com/12004932/216440764-6d5974ac-38cf-4447-b170-fb2c15744df1.gif)