### PR TITLE
Allow parallel builds with low ram machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 *build
 *Plugins
 .DS_Store
+
+.vscode/
+.cache/
+
+Resources/Fonts/InterUnicode_*.ttf
+Resources/Filesystem_*.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,18 +306,14 @@ endif()
 
 file(GLOB PlugDataBinaryDataSources
     ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/IconFont.ttf
-    ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/InterUnicode_0.ttf
-    ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/InterUnicode_1.ttf
-    ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/InterUnicode_2.ttf
+    ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/InterUnicode_*.ttf
     ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/InterBold.ttf
     ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/InterSemiBold.ttf
     ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/InterThin.ttf
     ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/IBMPlexMono.ttf
     ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Fonts/GoNotoCurrent.ttf
     ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Icons/plugdata_logo.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Filesystem_0.zip
-    ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Filesystem_1.zip
-    ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Filesystem_2.zip
+    ${CMAKE_CURRENT_SOURCE_DIR}/Resources/Filesystem_*.zip
     )
 
 file(GLOB StandaloneBinarySources

--- a/Resources/Scripts/package_resources.py
+++ b/Resources/Scripts/package_resources.py
@@ -143,7 +143,7 @@ changeWorkingDir("./..")
 makeArchive("Filesystem", "./", "./plugdata_version")
 removeDir("./plugdata_version")
 
-splitFile("./Fonts/InterUnicode.ttf", 3)
+splitFile("./Fonts/InterUnicode.ttf", 12)
 
-splitFile("./Filesystem.zip", 3)
+splitFile("./Filesystem.zip", 12)
 removeFile("./Filesystem.zip")


### PR DESCRIPTION
Split files more to get ram hunger for single process build < 2 gig
so you can do `-j4` or `-GNinja` on an 8 gig system