### PR TITLE
mara took the hyphens away!

### DIFF
--- a/Resources/Documentation/ELSE/adsr~.md
+++ b/Resources/Documentation/ELSE/adsr~.md
@@ -55,7 +55,7 @@ outlets:
 
 methods:
   - type: log <float>
-    description: non zero sets to "log" mode, "linear" otherwise
+    description: non-0 sets to "log" mode, "linear" otherwise
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/asr~.md
+++ b/Resources/Documentation/ELSE/asr~.md
@@ -41,7 +41,7 @@ outlets:
 
 methods:
   - type: log <float>
-    description: - non zero sets to "log" mode, "linear" otherwise
+    description: - non-0 sets to "log" mode, "linear" otherwise
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/autofade2~.md
+++ b/Resources/Documentation/ELSE/autofade2~.md
@@ -51,4 +51,4 @@ methods:
 draft: false
 ---
 
-[autofade2~] is an automatic fade in/out (with separate time for fade in/out) for multichannel inputs. It responds to a gate control and uses internal lookup tables for 7 different fading curves. A gate-on happens when the last input value was zero and the incoming value isn't. A gate-off happens when the last value was a non-zero value and the incoming value is 0 The maximum gain depends on the gate on level.
+[autofade2~] is an automatic fade in/out (with separate time for fade in/out) for multichannel inputs. It responds to a gate control and uses internal lookup tables for 7 different fading curves. A gate-on happens when the last input value was zero and the incoming value isn't. A gate-off happens when the last value was a non-0 value and the incoming value is 0 The maximum gain depends on the gate on level.

--- a/Resources/Documentation/ELSE/autofade~.md
+++ b/Resources/Documentation/ELSE/autofade~.md
@@ -46,4 +46,4 @@ methods:
 draft: false
 ---
 
-[autofade~] is an automatic fade in/out for multichannel inputs. It responds to a gate control and uses internal lookup tables for 7 different fading curves. A gate-on happens when the last input value was zero and the incoming value isn't. A gate-off happens when the last value was a non-zero value and the incoming value is 0! The maximum gain depends on the gate on level.
+[autofade~] is an automatic fade in/out for multichannel inputs. It responds to a gate control and uses internal lookup tables for 7 different fading curves. A gate-on happens when the last input value was zero and the incoming value isn't. A gate-off happens when the last value was a non-0 value and the incoming value is 0! The maximum gain depends on the gate on level.

--- a/Resources/Documentation/ELSE/autotune.md
+++ b/Resources/Documentation/ELSE/autotune.md
@@ -34,7 +34,7 @@ methods:
   - type: base <float>
     description: MIDI pitch base
   - type: bypass <float>
-    description: non-zero sets to bypass mode
+    description: non-0 sets to bypass mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/autotune2.md
+++ b/Resources/Documentation/ELSE/autotune2.md
@@ -28,7 +28,7 @@ outlets:
 
 methods:
   - type: bypass <float>
-    description: non zero sets to bypass mode
+    description: non-0 sets to bypass mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/bandpass~.md
+++ b/Resources/Documentation/ELSE/bandpass~.md
@@ -26,7 +26,7 @@ inlets:
     description: signal to be filtered
   2nd:
   - type: signal
-    description: central frequency in Hertz
+    description: central frequency in Hz
   3rd:
   - type: signal
     description: filter resonance (Q or bandwidth)

--- a/Resources/Documentation/ELSE/bandstop~.md
+++ b/Resources/Documentation/ELSE/bandstop~.md
@@ -1,7 +1,7 @@
 ---
 title: bandstop~
 
-description: band stop filter
+description: bandstop filter
 
 categories:
  - object

--- a/Resources/Documentation/ELSE/bicoeff2.md
+++ b/Resources/Documentation/ELSE/bicoeff2.md
@@ -10,13 +10,13 @@ pdcategory: ELSE, Filters, Data Math
 
 arguments:
   - type: symbol
-    description: (optional) sets type <hipass/etc>, (default='off')
+    description: (optional) sets type <highpass/etc>, (default='off')
   - type: float
     description: sets cutoff/center frequency (default=0)
   - type: float
     description: sets Q/slope (default=1)
   - type: float
-    description: sets gain in db (default=0)
+    description: sets gain in dB (default=0)
 
 inlets:
   1st:
@@ -33,7 +33,7 @@ inlets:
     description: sets "Q" or "Slope" and outputs coefficients
   3rd:
   - type: float
-    description: sets gain in db
+    description: sets gain in dB
 
 outlets:
   1st:
@@ -44,7 +44,7 @@ methods:
   - type: qs <float>
     description: sets "Q" or "Slope" and outputs coefficients
   - type: gain <float>
-    description: sets gain in db and outputs coefficients
+    description: sets gain in dB and outputs coefficients
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/bin.shift~.md
+++ b/Resources/Documentation/ELSE/bin.shift~.md
@@ -12,7 +12,7 @@ arguments:
   - description: sets shift number
     type: float
     default: 0
-  - description: non-zero sets to wrap mode
+  - description: non-0 sets to wrap mode
     type: float
     default: 0
 
@@ -31,7 +31,7 @@ outlets:
 
 methods:
   - type: wrap <float>
-    description: non-zero sets to wrap mode
+    description: non-0 sets to wrap mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/bitnormal~.md
+++ b/Resources/Documentation/ELSE/bitnormal~.md
@@ -12,7 +12,7 @@ arguments:
 inlets:
   1st:
   - type: signal
-    description: input whose nan/inf/denormal values are replaced with 0
+    description: input whose NaN/Inf/denormal values are replaced with 0
   
 outlets:
   1st:

--- a/Resources/Documentation/ELSE/bl.osc~.md
+++ b/Resources/Documentation/ELSE/bl.osc~.md
@@ -16,7 +16,7 @@ arguments:
     description: number of partials
     default: 1
   - type: float
-    description: frequency in hertz
+    description: frequency in Hz
     default: 0
   - type: float
     description: phase offset

--- a/Resources/Documentation/ELSE/blip~.md
+++ b/Resources/Documentation/ELSE/blip~.md
@@ -50,4 +50,4 @@ methods:
 draft: false
 ---
 
-[blip~] uses DSF (Discrete-Summation Formulae) to generate waveforms as a sum of cosines. It takes a frequency in hertz for the fundamental, a number of harmonics, a multiplier for the partials after the first one and the lowest harmonic number (by default it generates an impulse waveform). This object is based on Csound's 'gbuzz' opcode.
+[blip~] uses DSF (Discrete-Summation Formulae) to generate waveforms as a sum of cosines. It takes a frequency in Hz for the fundamental, a number of harmonics, a multiplier for the partials after the first one and the lowest harmonic number (by default it generates an impulse waveform). This object is based on Csound's 'gbuzz' opcode.

--- a/Resources/Documentation/ELSE/blocksize~.md
+++ b/Resources/Documentation/ELSE/blocksize~.md
@@ -36,4 +36,4 @@ methods:
 draft: false
 ---
 
-[blocksize~] reports the block size when the audio is turned on, when it changes or via a bang. The period is reported in samples or ms, but you can also query the corresponding frequency in hz. The default output is the block size in samples. The DSP needs to be turned on so a block size is detected!
+[blocksize~] reports the block size when the audio is turned on, when it changes or via a bang. The period is reported in samples or ms, but you can also query the corresponding frequency in Hz. The default output is the block size in samples. The DSP needs to be turned on so a block size is detected!

--- a/Resources/Documentation/ELSE/brown~.md
+++ b/Resources/Documentation/ELSE/brown~.md
@@ -36,4 +36,4 @@ methods:
 draft: false
 ---
 
-[brown~] is a brown noise generator (aka brownian noise or red noise), whose spectral energy drops 6dB per octave (sounding less hissy than white noise). It is implemented as a bounded random walk (based on a pseudo random number generator algorithm). By default, the maximum step is 0.125, but you can set that. If a signal is connected, non zero values generate new random steps.
+[brown~] is a brown noise generator (aka brownian noise or red noise), whose spectral energy drops 6dB per octave (sounding less hissy than white noise). It is implemented as a bounded random walk (based on a pseudo random number generator algorithm). By default, the maximum step is 0.125, but you can set that. If a signal is connected, non-0 values generate new random steps.

--- a/Resources/Documentation/ELSE/canvas.mouse.md
+++ b/Resources/Documentation/ELSE/canvas.mouse.md
@@ -13,7 +13,7 @@ arguments:
   description: depth
   default: 0
 - type: float
-  description: non zero sets "position mode"
+  description: non-0 sets "position mode"
   default: 0
 
 inlets:

--- a/Resources/Documentation/ELSE/chorus~.md
+++ b/Resources/Documentation/ELSE/chorus~.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Effects
 
 arguments:
-  - description: rate in hertz
+  - description: rate in Hz
     type: float
     default: 0
   - description: depth
@@ -25,7 +25,7 @@ inlets:
     description: input to chorus
   2nd:
   - type: float
-    description: rate in hertz
+    description: rate in Hz
   3rd:
   - type: float
     description: depth

--- a/Resources/Documentation/ELSE/chrono.md
+++ b/Resources/Documentation/ELSE/chrono.md
@@ -16,7 +16,7 @@ inlets:
   - type: bang
     description: rewinds chronometer or timer
   - type: float
-    description: rewinds chronometer or non-zero starts or continues, zero stops
+    description: rewinds chronometer or non-0 starts or continues, zero stops
   - type: list
     description: sets timer length in minutes / seconds
 

--- a/Resources/Documentation/ELSE/circle.md
+++ b/Resources/Documentation/ELSE/circle.md
@@ -34,9 +34,9 @@ methods:
   - type: xrange <float>
     description: sets range (minimum and maximum values of x)
   - type: line <float>
-    description: non zero sets line visibility
+    description: non-0 sets line visibility
   - type: grid <float>
-    description: non zero sets grid visibility
+    description: non-0 sets grid visibility
   - type: bgcolor1 <f, f, f>
     description: sets background color inside circle in RGB
   - type: bgcolor2 <f, f, f>
@@ -46,9 +46,9 @@ methods:
   - type: fgcolor <f, f, f>
     description: sets foreground color in RGB
   - type: init <float>
-    description: non zero sets to init mode
+    description: non-0 sets to init mode
   - type: clip <float>
-    description: non zero clips inside the circle
+    description: non-0 clips inside the circle
     
 flags:
   - name:

--- a/Resources/Documentation/ELSE/click.md
+++ b/Resources/Documentation/ELSE/click.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, UI, Triggers and Clocks
 
 arguments:
 - type: float
-  description: sets mode, 0 is "abstraction" mode, non-zero is "subpatch" mode
+  description: sets mode, 0 is "abstraction" mode, non-0 is "subpatch" mode
   default: 0
 
 inlets:

--- a/Resources/Documentation/ELSE/clock.md
+++ b/Resources/Documentation/ELSE/clock.md
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: non-zero starts the clock, zero stops it
+    description: non-0 starts the clock, zero stops it
   - type: bang
     description: resyncs the clock
   2nd:

--- a/Resources/Documentation/ELSE/comb.filt~.md
+++ b/Resources/Documentation/ELSE/comb.filt~.md
@@ -15,7 +15,7 @@ arguments:
   - type: float
     description: decay coefficient
   - type: float
-    description: decay mode <0> or gain mode <non-zero>
+    description: decay mode <0> or gain mode <non-0>
     default: t60
 
 inlets:
@@ -42,7 +42,7 @@ methods:
   - type: clear
     description: clears the delay buffer
   - type: gain <float>
-    description: non zero sets to gain mode instead of 't60'
+    description: non-0 sets to gain mode instead of 't60'
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/count.md
+++ b/Resources/Documentation/ELSE/count.md
@@ -50,7 +50,7 @@ methods:
   - type: down
     description: sets count direction downwards
   - type: alt <float>
-    description: non-zero sets to alternating mode (between up/down)
+    description: non-0 sets to alternating mode (between up/down)
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/cusp~.md
+++ b/Resources/Documentation/ELSE/cusp~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Random and Noise, Signal Generators
 
 arguments:
   - type: float
-    description: sets frequency in hertz
+    description: sets frequency in Hz
     default: Nyquist
   - type: float
     description: sets 'a'
@@ -39,5 +39,5 @@ draft: false
 
 [cusp~] is a chaotic generator using the difference equation;
 y[n] = a - b * sqrt(abs(y[n-1]))
-The output rate of the equation is given in hertz (default: Nyquist).
+The output rate of the equation is given in Hz (default: Nyquist).
 Object based on SuperCollider's "CuspN" UGEN.

--- a/Resources/Documentation/ELSE/db2lin.md
+++ b/Resources/Documentation/ELSE/db2lin.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Converters
 
 arguments:
-- description: minimum value (can be as low as "-inf")
+- description: minimum value (can be as low as "-Inf")
   type: float
   default: -100
 

--- a/Resources/Documentation/ELSE/db2lin~.md
+++ b/Resources/Documentation/ELSE/db2lin~.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Converters
 
 arguments:
-- description: minimum value (can be as low as "-inf")
+- description: minimum value (can be as low as "-Inf")
   type: float
   default: -100
 

--- a/Resources/Documentation/ELSE/deg2rad.md
+++ b/Resources/Documentation/ELSE/deg2rad.md
@@ -15,10 +15,10 @@ arguments:
 
 inlets:
   1st:
-  - type: float
-    description: input degree value to convert to radians
   - type: bang
     description: convert the last value
+  - type: float
+    description: input degree value to convert to radians
 
 outlets:
   1st:

--- a/Resources/Documentation/ELSE/del~ in.md
+++ b/Resources/Documentation/ELSE/del~ in.md
@@ -36,7 +36,7 @@ methods:
   - type: size <float>
     description: changes the delay size
   - type: freeze <float>
-    description: non zero freezes, zero unfreezes
+    description: non-0 freezes, zero unfreezes
 
 ---
 

--- a/Resources/Documentation/ELSE/downsample~.md
+++ b/Resources/Documentation/ELSE/downsample~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Effects
 
 arguments:
 - type: float
-  description: rate in hertz
+  description: rate in Hz
   default: Pd's sample rate
 - type: float
   description: interpolation 0 (off) or 1 (on)
@@ -24,7 +24,7 @@ inlets:
     description: restart cycle and sync output
   2nd:
   - type: float/signal
-    description: rate (in Hertz) used to downsample the input signal
+    description: rate (in Hz) used to downsample the input signal
 
 outlets:
   1st:
@@ -37,5 +37,5 @@ methods:
 
 ---
 
-[downsample~] samples a signal received in the left inlet at a frequency rate in hertz. It can operate with or without interpolation.
+[downsample~] samples a signal received in the left inlet at a frequency rate in Hz. It can operate with or without interpolation.
 

--- a/Resources/Documentation/ELSE/drum.seq.md
+++ b/Resources/Documentation/ELSE/drum.seq.md
@@ -53,7 +53,7 @@ methods:
   - type: size <float>
     description: sets cell size in pixels (clears data)
   - type: embed <float>
-    description: non zero save internal contents with the object
+    description: non-0 save internal contents with the object
 
   - type: export <list>
     description: array of contexts via the "export" message

--- a/Resources/Documentation/ELSE/duck~.md
+++ b/Resources/Documentation/ELSE/duck~.md
@@ -49,7 +49,7 @@ methods:
   - type: release <float>
     description: sets release time in ms
   - type: mix <float>
-    description: non zero mixes with control signal
+    description: non-0 mixes with control signal
 
 
 draft: false

--- a/Resources/Documentation/ELSE/dust2~.md
+++ b/Resources/Documentation/ELSE/dust2~.md
@@ -33,4 +33,4 @@ methods:
 
 ---
 
-[dust2~] is based on SuperCollider's "Dust2" UGEN and outputs random impulse values (from -1 to 1) at random times according to a density parameter. The difference to SuperCollider's is that it only produces actual impulses (one non zero value in between 0 valued samples).
+[dust2~] is based on SuperCollider's "Dust2" UGEN and outputs random impulse values (from -1 to 1) at random times according to a density parameter. The difference to SuperCollider's is that it only produces actual impulses (one non-0 value in between 0 valued samples).

--- a/Resources/Documentation/ELSE/dust~.md
+++ b/Resources/Documentation/ELSE/dust~.md
@@ -33,5 +33,5 @@ methods:
 
 ---
 
-[dust~] is based on SuperCollider's "Dust" UGEN and outputs random impulse values (only positive values up to 1) at random times according to a density parameter. The difference to SuperCollider's is that it only produces actual impulses (one non zero value in between 0 valued samples).
+[dust~] is based on SuperCollider's "Dust" UGEN and outputs random impulse values (only positive values up to 1) at random times according to a density parameter. The difference to SuperCollider's is that it only produces actual impulses (one non-0 value in between 0 valued samples).
 

--- a/Resources/Documentation/ELSE/eqdiv.md
+++ b/Resources/Documentation/ELSE/eqdiv.md
@@ -18,10 +18,10 @@ arguments:
 
 inlets:
   1st:
-  - type: float
-    description: set number of equal divisions and generate scale
   - type: bang
     description: generate scale
+  - type: float
+    description: set number of divisions and generate scale
   2nd:
   - type: float
     description: set interval ratio

--- a/Resources/Documentation/ELSE/eq~.md
+++ b/Resources/Documentation/ELSE/eq~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Filters, Effects, Mixing and Routing
 
 arguments:
 - type: float
-  description: central frequency in Hertz
+  description: central frequency in Hz
   default: 0
 - type: float
   description: resonance, either in 'Q' or 'bw'
@@ -25,7 +25,7 @@ inlets:
     description: signal to be filtered
   2nd:
   - type: float/signal
-    description: central frequency in Hertz
+    description: central frequency in Hz
   3rd:
   - type: float/signal
     description: filter resonance (Q or bandwidth)

--- a/Resources/Documentation/ELSE/fbdelay~.md
+++ b/Resources/Documentation/ELSE/fbdelay~.md
@@ -46,7 +46,7 @@ methods:
   - type: size <float>
     description: changes the maximum delay size (in ms)
   - type: freeze <float>
-    description: non zero freezes, zero unfreezes
+    description: non-0 freezes, zero unfreezes
   - type: clear
     description: clears the delay buffer
   - type: gain <float>

--- a/Resources/Documentation/ELSE/fbsine2~.md
+++ b/Resources/Documentation/ELSE/fbsine2~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: Nyquist
 - type: float
   description: sets 'im'
@@ -33,7 +33,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
   - type: list
     description: 2 floats set x[n-1] and y[n-1] respectively
 

--- a/Resources/Documentation/ELSE/fbsine~.md
+++ b/Resources/Documentation/ELSE/fbsine~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial feedback value

--- a/Resources/Documentation/ELSE/fdn.rev~.md
+++ b/Resources/Documentation/ELSE/fdn.rev~.md
@@ -43,7 +43,7 @@ methods:
   - type: set <list>
     description: set number of lines and min/max times
   - type: exp <float>
-    description: non zero sets delay times exponentially
+    description: non-0 sets delay times exponentially
   - type: clear
     description: clears the delay lines and reverberation
   - type: print

--- a/Resources/Documentation/ELSE/ffdelay~.md
+++ b/Resources/Documentation/ELSE/ffdelay~.md
@@ -35,7 +35,7 @@ methods:
   - type: size <float>
     description: changes the delay size
   - type: freeze <float>
-    description: non zero freezes, zero unfreezes
+    description: non-0 freezes, zero unfreezes
   - type: clear
     description: clears the delay buffer
 

--- a/Resources/Documentation/ELSE/flanger~.md
+++ b/Resources/Documentation/ELSE/flanger~.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Effects
 
 arguments:
-- description: rate in hertz
+- description: rate in Hz
   type: float
   default: 0
 - description: depth in ms

--- a/Resources/Documentation/ELSE/freeze~.md
+++ b/Resources/Documentation/ELSE/freeze~.md
@@ -16,7 +16,7 @@ inlets:
     description: input to freeze
   2nd:
   - type: float
-    description: non-zero freezes (or refreezes), 0 unfreezes
+    description: non-0 freezes (or refreezes), 0 unfreezes
 
 outlets:
   1st:

--- a/Resources/Documentation/ELSE/freq.shift~.md
+++ b/Resources/Documentation/ELSE/freq.shift~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Effects
 
 arguments:
 - type: float
-  description: the frequency shift value in hertz
+  description: the frequency shift value in Hz
   default: 0
 
 inlets:

--- a/Resources/Documentation/ELSE/function.md
+++ b/Resources/Documentation/ELSE/function.md
@@ -73,7 +73,7 @@ methods:
   - type: receive <symbol>
     description: sets receive symbol
   - type: init <float>
-    description: nonzero sets to init mode
+    description: non-0 sets to init mode
 
 ---
 

--- a/Resources/Documentation/ELSE/gain2~.md
+++ b/Resources/Documentation/ELSE/gain2~.md
@@ -51,7 +51,7 @@ methods:
   - type: ramp <float>
     description: sets ramp time in ms for slider values (default 20)
   - type: init <float>
-    description: non zero sets to init mode
+    description: non-0 sets to init mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/gain~.md
+++ b/Resources/Documentation/ELSE/gain~.md
@@ -45,7 +45,7 @@ methods:
   - type: ramp <float>
     description: sets ramp time in ms for slider values (default 20)
   - type: init <float>
-    description: non zero sets to init mode
+    description: non-0 sets to init mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/gate2imp~.md
+++ b/Resources/Documentation/ELSE/gate2imp~.md
@@ -21,5 +21,5 @@ outlets:
 
 ---
 
-[gate2imp~] converts gates to impulses. It sends an impulse when receiving a gate (0 to non 0 transitions) where the impulse value is the same as the gate.
+[gate2imp~] converts gates to impulses. It sends an impulse when receiving a gate (0 to non-0 transitions) where the impulse value is the same as the gate.
 

--- a/Resources/Documentation/ELSE/gaussian~.md
+++ b/Resources/Documentation/ELSE/gaussian~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial width

--- a/Resources/Documentation/ELSE/gbman~.md
+++ b/Resources/Documentation/ELSE/gbman~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Random and Noise, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: Nyquist
 - type: float
   description: sets initial feedback value of y[n-1]
@@ -21,7 +21,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
   - type: list
     description: 2 floats set y[n-1] and y[n-2], respectively
 

--- a/Resources/Documentation/ELSE/gendyn~.md
+++ b/Resources/Documentation/ELSE/gendyn~.md
@@ -31,9 +31,9 @@ methods:
   - type: frange <f, f>
     description: set minimum and maximum frequencies (default 220, 440)
   - type: freq_step <float>
-    description: set maximum frequency step in percentage (default 50)
+    description: set maximum frequency step in % (default 50)
   - type: amp_step <float>
-    description: set maximum amplitude step in percentage (default 25)
+    description: set maximum amplitude step in % (default 25)
   - type: interp <float>
     description: sets interpolation mode (default 1, linear)
   - type: seed <float>

--- a/Resources/Documentation/ELSE/grain.live~.md
+++ b/Resources/Documentation/ELSE/grain.live~.md
@@ -60,7 +60,7 @@ methods:
   - type: dur <f>
     description: sets cloud event duration in ms (default 500)
   - type: sync <f>
-    description: non zero sets to synchronous mode (default 0)
+    description: non-0 sets to synchronous mode (default 0)
   - type: size <f, f>
     description: sets min/max grain sizes in ms (default 50 to 450)
   - type: transp <f, f>
@@ -76,7 +76,7 @@ methods:
   - type: env <any>
     description: envelope type (sin, hann, tri, gauss) or function list
   - type: autotune <f>
-    description: non-zero autotunes to a given scale (default 0)
+    description: non-0 autotunes to a given scale (default 0)
   - type: scale <list>
     description: scale to autotune to in cents (default equal temperament)
 

--- a/Resources/Documentation/ELSE/grain.sampler~.md
+++ b/Resources/Documentation/ELSE/grain.sampler~.md
@@ -58,7 +58,7 @@ methods:
   - type: n <float>
     description: number of grains in cloud event (minimum 1, maximum 256)
   - type: sync <f>
-    description: non zero sets to synchronous mode (default 0)
+    description: non-0 sets to synchronous mode (default 0)
   - type: dur <f>
     description: sets cloud event duration in ms (default 500)
   - type: set <symbol>
@@ -80,7 +80,7 @@ methods:
   - type: env <any>
     description: envelope type (sin, hann, tri, gauss) or function list
   - type: autotune <f>
-    description: non-zero autotunes to a given scale (default 0)
+    description: non-0 autotunes to a given scale (default 0)
   - type: scale <list>
     description: scale to autotune to in cents (default equal temperament)
 

--- a/Resources/Documentation/ELSE/grain.synth~.md
+++ b/Resources/Documentation/ELSE/grain.synth~.md
@@ -58,7 +58,7 @@ methods:
   - type: set <symbol>
     description: sets table name with waveform
   - type: sync <f>
-    description: non zero sets to synchronous mode (default 0)
+    description: non-0 sets to synchronous mode (default 0)
   - type: dur <f>
     description: sets cloud event duration in ms (default 500)
   - type: size <f, f>
@@ -72,7 +72,7 @@ methods:
   - type: env <any>
     description: envelope type (sin, hann, tri, gauss) or function list
   - type: autotune <f>
-    description: non-zero autotunes to a given scale (default 0)
+    description: non-0 autotunes to a given scale (default 0)
   - type: scale <list>
     description: scale to autotune to in cents (default equal temperament)
   - type: base <f>

--- a/Resources/Documentation/ELSE/henon~.md
+++ b/Resources/Documentation/ELSE/henon~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Random and Noise, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: Nyquist
 - type: float
   description: sets a
@@ -27,7 +27,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
   - type: list
     description: 2 floats set y[n-1] and y[n-2], respectively
 

--- a/Resources/Documentation/ELSE/highpass~.md
+++ b/Resources/Documentation/ELSE/highpass~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Filters
 
 arguments:
 - type: float
-  description: central frequency in Hertz
+  description: central frequency in Hz
   default: 0
 - type: float
   description: resonance, either in 'Q' or 'bw'
@@ -21,7 +21,7 @@ inlets:
     description: signal to be filtered
   2nd:
   - type: float/signal
-    description: central frequency in Hertz
+    description: central frequency in Hz
   3rd:
   - type: float/signal
     description: filter resonance (Q or bandwidth)

--- a/Resources/Documentation/ELSE/highshelf~.md
+++ b/Resources/Documentation/ELSE/highshelf~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Filters, Mixing and Routing
 
 arguments:
 - type: float
-  description: shelving frequency in Hertz
+  description: shelving frequency in Hz
   default: 0
 - type: float
   description: slope from 0 to 1
@@ -24,7 +24,7 @@ inlets:
     description: signal to be filtered
   2nd:
   - type: float/signal
-    description: shelving frequency in Hertz
+    description: shelving frequency in Hz
   3rd:
   - type: float/signal
     description: slope (from 0 to 1)

--- a/Resources/Documentation/ELSE/hip.bw~.md
+++ b/Resources/Documentation/ELSE/hip.bw~.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Filters
 
 arguments:
-- description: cutoff in hertz
+- description: cutoff in Hz
   type: float
   default: 0
 - description: order of the filter from 2 to 100
@@ -22,7 +22,7 @@ inlets:
     description: the signal to be filtered
   2nd:
   - type: float
-    description: cutoff frequency in hertz
+    description: cutoff frequency in Hz
   3rd:
   - type: float
     description: order of the filter

--- a/Resources/Documentation/ELSE/histogram.md
+++ b/Resources/Documentation/ELSE/histogram.md
@@ -46,7 +46,7 @@ methods:
   - type: import <list>
     description: import histogram data as a list
   - type: embed <float>
-    description: non zero embeds histogram data with the patch
+    description: non-0 embeds histogram data with the patch
   - type: size <float>
     description: clears and resizes table
   - type: name <symbol>

--- a/Resources/Documentation/ELSE/hz2rad.md
+++ b/Resources/Documentation/ELSE/hz2rad.md
@@ -1,6 +1,6 @@
 ---
 title: hz2rad
-description: Hertz to radians-per-sample conversion
+description: Hz to radians-per-sample conversion
 
 categories:
  - object
@@ -15,7 +15,7 @@ arguments:
 inlets:
   1st:
   - type: float/list
-    description: hertz value(s)
+    description: Hz value(s)
   - type: bang
     description: convert or output the last converted value (only float)
 
@@ -30,6 +30,6 @@ methods:
 
 ---
 
-[hz2rad] converts a frequency in Hertz to "Radians per Sample" - which depends on the patch's sample rate (sr). The conversion formula is;
+[hz2rad] converts a frequency in Hz to "Radians per Sample" - which depends on the patch's sample rate (sr). The conversion formula is;
 rad = (hz * 2*pi / sr).
 

--- a/Resources/Documentation/ELSE/ikeda~.md
+++ b/Resources/Documentation/ELSE/ikeda~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Random and Noise, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: Nyquist
 - type: float
   description: sets initial "u" parameter
@@ -24,7 +24,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
 
 outlets:
   1st:

--- a/Resources/Documentation/ELSE/imp2~.md
+++ b/Resources/Documentation/ELSE/imp2~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial width

--- a/Resources/Documentation/ELSE/impulse.md
+++ b/Resources/Documentation/ELSE/impulse.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Triggers and Clocks
 
 arguments:
-- description: frequency in hertz
+- description: frequency in Hz
   type: float
   default: 0
 - description: initial phase offset

--- a/Resources/Documentation/ELSE/impulse2~.md
+++ b/Resources/Documentation/ELSE/impulse2~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial width

--- a/Resources/Documentation/ELSE/impulse~.md
+++ b/Resources/Documentation/ELSE/impulse~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial phase offset

--- a/Resources/Documentation/ELSE/imp~.md
+++ b/Resources/Documentation/ELSE/imp~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial phase offset

--- a/Resources/Documentation/ELSE/latoocarfian~.md
+++ b/Resources/Documentation/ELSE/latoocarfian~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: nyquist
 - type: float
   description: sets a
@@ -34,7 +34,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
   - type: list
     description: 2 floats set x[n-1] and y[n-1], respectively
 

--- a/Resources/Documentation/ELSE/lfnoise.md
+++ b/Resources/Documentation/ELSE/lfnoise.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Random and Noise, Envelopes and LFOs
 
 arguments:
-- description: frequency in hertz
+- description: frequency in Hz
   type: float
   default: 0
 - description: interpolation off (0) or on (1)
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: frequency in hertz up to 100 (negative values accepted)
+    description: frequency in Hz up to 100 (negative values accepted)
   2nd:
   - type: bang
     description: reset to a new random value
@@ -35,7 +35,7 @@ flags:
 
 methods:
   - type: interp <float>
-    description: non zero sets to linear interpolation
+    description: non-0 sets to linear interpolation
   - type: seed <float>
     description: a float sets seed, no float sets a unique internal
 

--- a/Resources/Documentation/ELSE/lfnoise~.md
+++ b/Resources/Documentation/ELSE/lfnoise~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Random and Noise, Signal Generators, Envelopes and LFOs
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: interpolation 0 (off) or 1 (on)
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency input in hertz
+    description: frequency input in Hz
   2nd:
   - type: signal
     description: impulse forces a new random value
@@ -41,5 +41,5 @@ methods:
 
 ---
 
-[lfnoise~] is a low frequency (band limited) noise with or without interpolation. It generates random values (between -1 and 1) at a rate in hertz (negative frequencies accepted). It also has a 'sync' inlet that forces the object to generate a new random value when receiving an impulse. Use the seed message if you want a reproducible output.
+[lfnoise~] is a low frequency (band limited) noise with or without interpolation. It generates random values (between -1 and 1) at a rate in Hz (negative frequencies accepted). It also has a 'sync' inlet that forces the object to generate a new random value when receiving an impulse. Use the seed message if you want a reproducible output.
 

--- a/Resources/Documentation/ELSE/lfo.md
+++ b/Resources/Documentation/ELSE/lfo.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Envelopes and LFOs
 
 arguments:
-- description: sets frequency in hertz (default 0)
+- description: sets frequency in Hz (default 0)
   type: float
   default: 0
 - description: sets initial phase from 0 - 1 (default 0)
@@ -22,7 +22,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: frequency in hertz up to 100 (negative values accepted)
+    description: frequency in Hz up to 100 (negative values accepted)
   - type: anything
     description: sets waveform (sine, tri, saw, vsaw, and square)
   2nd:

--- a/Resources/Documentation/ELSE/limit.md
+++ b/Resources/Documentation/ELSE/limit.md
@@ -13,7 +13,7 @@ arguments:
   description: initial time limit
   default: 0 - no limit
 - type: float
-  description: non zero sets to ignore mode
+  description: non-0 sets to ignore mode
   default: 0
 
 inlets:

--- a/Resources/Documentation/ELSE/lin2db.md
+++ b/Resources/Documentation/ELSE/lin2db.md
@@ -23,5 +23,5 @@ outlets:
 draft: false
 ---
 
-[lin2db] is a simple abstraction that converts amplitude values from linear to a deciBel Full Scale (dBFS). Conversion expression: dbFS = log10(amp) * 20, see the implementation inside the abstraction.
+[lin2db] is a simple abstraction that converts amplitude values from linear to a deciBel Full Scale (dBFS). Conversion expression: dBFS = log10(amp) * 20, see the implementation inside the abstraction.
 

--- a/Resources/Documentation/ELSE/lin2db~.md
+++ b/Resources/Documentation/ELSE/lin2db~.md
@@ -23,5 +23,5 @@ outlets:
 draft: false
 ---
 
-[lin2db~] is a simple abstraction that converts amplitude values from linear to a deciBel Full Scale (dBFS). Conversion expression: dbFS = log10(amp) * 20, see the implementation inside the abstraction.
+[lin2db~] is a simple abstraction that converts amplitude values from linear to a deciBel Full Scale (dBFS). Conversion expression: dBFS = log10(amp) * 20, see the implementation inside the abstraction.
 

--- a/Resources/Documentation/ELSE/lincong~.md
+++ b/Resources/Documentation/ELSE/lincong~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: nyquist
 - type: float
   description: sets 'a'
@@ -28,7 +28,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
   - type: list
     description: 4 floats sets 'a', 'c', 'm' and y[n-1]
 

--- a/Resources/Documentation/ELSE/logistic~.md
+++ b/Resources/Documentation/ELSE/logistic~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: 0
 - type: float
   description: sets p
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
   2nd:
   - type: float/signal
     description: 'p' parameter (from 0 to 1)

--- a/Resources/Documentation/ELSE/lop.bw~.md
+++ b/Resources/Documentation/ELSE/lop.bw~.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Filters
 
 arguments:
-- description: cutoff in hertz
+- description: cutoff in Hz
   type: float
   default: 0
 - description: order of the filter from 2 to 100
@@ -22,7 +22,7 @@ inlets:
     description: the signal to be filtered
   2nd:
   - type: float
-    description: cutoff frequency in hertz
+    description: cutoff frequency in Hz
   3rd:
   - type: float
     description: order of the filter

--- a/Resources/Documentation/ELSE/lorenz~.md
+++ b/Resources/Documentation/ELSE/lorenz~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: nyquist
 - type: float
   description: sets 's'
@@ -37,7 +37,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
   - type: list
     description: 3 floats set x[n-1], y[n-1] and z[n-1] respectively
 

--- a/Resources/Documentation/ELSE/lowpass~.md
+++ b/Resources/Documentation/ELSE/lowpass~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Filters
 
 arguments:
 - type: float
-  description: central frequency in Hertz
+  description: central frequency in Hz
   default: 0
 - type: float
   description: resonance, either in 'Q' (default) or 'bw'
@@ -22,7 +22,7 @@ inlets:
     description: signal to be filtered
   2nd:
   - type: float/signal
-    description: central frequency in Hertz
+    description: central frequency in Hz
   3rd:
   - type: float/signal
     description: filter resonance (Q or bandwidth)

--- a/Resources/Documentation/ELSE/lowshelf~.md
+++ b/Resources/Documentation/ELSE/lowshelf~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Filters
 
 arguments:
 - type: float
-  description: shelving frequency in Hertz
+  description: shelving frequency in Hz
   default: 0
 - type: float
   description: slope from 0 to 1
@@ -25,7 +25,7 @@ inlets:
     description: signal to be filtered
   2nd:
   - type: float/signal
-    description: shelving frequency in Hertz
+    description: shelving frequency in Hz
   3rd:
   - type: float/signal
     description: slope (from 0 to 1)

--- a/Resources/Documentation/ELSE/markov.md
+++ b/Resources/Documentation/ELSE/markov.md
@@ -13,7 +13,7 @@ arguments:
   description: sets order
   default: 1
 - type: float
-  description: non-zero sets to savestate mode 
+  description: non-0 sets to savestate mode 
   default: 0
 
 inlets:

--- a/Resources/Documentation/ELSE/messbox.md
+++ b/Resources/Documentation/ELSE/messbox.md
@@ -32,7 +32,7 @@ flags:
 - name: -bgcolor <f, f, f>
   description: background color
 - name: -bold
-  description: non-zero sets to bold
+  description: non-0 sets to bold
 
 methods:
   - type: set <anything>
@@ -44,7 +44,7 @@ methods:
   - type: fontsize <float>
     description: sets font size
   - type: bold
-    description: non-zero sets to bold
+    description: non-0 sets to bold
   - type: -bgcolor <f, f, f>
     description: sets background color
   - type: fgcolor <f, f, f>

--- a/Resources/Documentation/ELSE/metronome.md
+++ b/Resources/Documentation/ELSE/metronome.md
@@ -18,7 +18,7 @@ inlets:
   - type: bang
     description: start or restart metronome
   - type: float
-    description: non-zero (re)starts, zero stops
+    description: non-0 (re)starts, zero stops
   2nd:
   - type: float
     description: set tempo value in BPM

--- a/Resources/Documentation/ELSE/midi.md
+++ b/Resources/Documentation/ELSE/midi.md
@@ -35,7 +35,7 @@ flags:
 
 methods:
   - type: loop <float>
-    description: non-zero sets to loop mode
+    description: non-0 sets to loop mode
   - type: record
     description: starts recording raw MIDI input
   - type: play
@@ -49,7 +49,7 @@ methods:
   - type: continue
     description: continues recording/playing
   - type: speed <float>
-    description: sets a reading speed in percentage of original
+    description: sets a reading speed in % of original
   - type: dump
     description: outputs the MIDI data stream at once
   - type: panic

--- a/Resources/Documentation/ELSE/midi2freq.md
+++ b/Resources/Documentation/ELSE/midi2freq.md
@@ -24,7 +24,7 @@ inlets:
 outlets:
   1st:
   - type: list
-    description: value(s) in hertz
+    description: value(s) in Hz
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/mono.md
+++ b/Resources/Documentation/ELSE/mono.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, MIDI
 
 arguments:
 - type: float
-  description: non-zero sets to legato mode
+  description: non-0 sets to legato mode
   default:
 
 inlets:
@@ -43,7 +43,7 @@ methods:
   - type: mode <float>
     description: priority mode (0: last, 1: high, 2: low)
   - type: legato <float>
-    description: non-zero - legato mode, zero - restores default
+    description: non-0 - legato mode, zero - restores default
   - type: flush
     description: sends a note off for the hanging note and clears memory
   - type: clear

--- a/Resources/Documentation/ELSE/mtx.ctl.md
+++ b/Resources/Documentation/ELSE/mtx.ctl.md
@@ -49,7 +49,7 @@ methods:
   - type: size <float>
     description: sets cell size in pixels
   - type: embed <float>
-    description: non zero save internal contents with the object
+    description: non-0 save internal contents with the object
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/multi.vsl.md
+++ b/Resources/Documentation/ELSE/multi.vsl.md
@@ -33,11 +33,11 @@ flags:
  - name:  -name <symbol>
    description: sets arrays name (default: internal), f 72;
  - name: -jump <float>
-   description: non zero sets jump on click mode (default: 0), f 72;
+   description: non-0 sets jump on click mode (default: 0), f 72;
  - name: -dim <float \, float>
    description: sets x/y dimensions (default: 200 127), f 72;
  - name: -init <float>
-    description: non zero sets to init mode (default: 0), f 72;
+    description: non-0 sets to init mode (default: 0), f 72;
  - name: -send <symbol>
     description: sets send symbol (default: empty), f 72;
  - name: -receive <symbol>
@@ -56,7 +56,7 @@ flags:
 
 methods:
   - type: mode <float>
-    description: non-zero sets to 'list mode'
+    description: non-0 sets to 'list mode'
   - type: dump
     description: outputs values sequentially as slider number / value
   - type: set <list>
@@ -76,13 +76,13 @@ methods:
   - type: n <float>
     description: sets number of sliders
   - type: jump <float>
-    description: non-zero sets jump on click mode
+    description: non-0 sets jump on click mode
   - type: import <list>
     description: sets number of sliders and values (and dumps them)
   - type: export
     description: outputs sliders values as a list
   - type: init <float>
-    description: non zero sets to jump on click mode
+    description: non-0 sets to jump on click mode
   - type: send <symbol>
     description: sets send name
   - type: receive <symbol>

--- a/Resources/Documentation/ELSE/note.md
+++ b/Resources/Documentation/ELSE/note.md
@@ -54,11 +54,11 @@ methods:
   - type: size <float>
     description: sets font size
   - type: bold <float>
-    description: non zero sets to bold
+    description: non-0 sets to bold
   - type: italic <float>
-    description: non zero sets to italic
+    description: non-0 sets to italic
   - type: underline <float>
-    description: non zero sets underline
+    description: non-0 sets underline
   - type: just <float>
     description: sets justification (0: left, 1: center, 2: right)
   - type: width <float>
@@ -70,7 +70,7 @@ methods:
   - type: bg <float>
     description: background flag (0 suppresses background)
   - type: outline <float>
-    description: non zero sets an outline
+    description: non-0 sets an outline
   - type: receive <symbol>
     description: sets receive symbol
 ---

--- a/Resources/Documentation/ELSE/nyquist~.md
+++ b/Resources/Documentation/ELSE/nyquist~.md
@@ -22,7 +22,7 @@ outlets:
 
 flags:
   - name: -khz
-    description: sets to frequency in khz
+    description: sets to frequency in kHz
   - name: -ms
     description: sets to period in ms
   - name: -sec
@@ -32,7 +32,7 @@ methods:
   - type: hz
     description: set and get the nyquist frequency in Hz
   - type: khz
-    description: set and get the nyquist frequency in Khz
+    description: set and get the nyquist frequency in kHz
   - type: ms
     description: set and get the nyquist period in ms
   - type: sec
@@ -40,4 +40,4 @@ methods:
 
 ---
 
-[nyquist~] reports the nyquist (which is half the sample rate) as a frequency or period. It sends it when loading the patch, when receiving a bang or when the sample rate changes. It reports it either in hz or khz and the period either in seconds os milliseconds. like [sr~], it doesn't report up/down sampling rates.
+[nyquist~] reports the nyquist (which is half the sample rate) as a frequency or period. It sends it when loading the patch, when receiving a bang or when the sample rate changes. It reports it either in Hz or kHz and the period either in seconds os milliseconds. like [sr~], it doesn't report up/down sampling rates.

--- a/Resources/Documentation/ELSE/oscbank~.md
+++ b/Resources/Documentation/ELSE/oscbank~.md
@@ -12,7 +12,7 @@ arguments:
   - description: number of oscillators 
     type: float
     default: 1
-  - description: fundamental frequency in hz
+  - description: fundamental frequency in Hz
     type: float
     default: 0
   - description: ramp time in ms
@@ -22,7 +22,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: fundamental frequency in hz
+    description: fundamental frequency in Hz
 
 outlets:
   1st:
@@ -39,7 +39,7 @@ flags:
   - name: -ramp <list>
     description: sets list of ramp times for all oscillators
   - name: -freq <float>
-    description: sets fundamental frequency in hz (default 0)
+    description: sets fundamental frequency in Hz (default 0)
   - name: -rampall <float>
     description: sets a ramp time for all oscillators (default all 10)
 

--- a/Resources/Documentation/ELSE/parabolic~.md
+++ b/Resources/Documentation/ELSE/parabolic~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
   - type: float
-    description: frequency in hertz
+    description: frequency in Hz
     default: 0
   - type: float
     description: initial phase offset
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float/signal
     description: phase sync (resets internal phase)

--- a/Resources/Documentation/ELSE/pattern.md
+++ b/Resources/Documentation/ELSE/pattern.md
@@ -16,7 +16,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: non-zero starts, zero stops the sequencer
+    description: non-0 starts, zero stops the sequencer
   - type: bang
     description: (re)start sequencer
   - type: list

--- a/Resources/Documentation/ELSE/perlin~.md
+++ b/Resources/Documentation/ELSE/perlin~.md
@@ -9,14 +9,14 @@ categories:
 pdcategory: ELSE, Random and Noise, Signal Generators
 
 arguments:
-- description: sets frequency in hertz
+- description: sets frequency in Hz
   type: float
   default: nyquist
 
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz
+    description: frequency in Hz
 
 outlets:
   1st:
@@ -34,5 +34,5 @@ methods:
 draft: false
 ---
 
-[perlin~] is an abstraction that implements 1-dimensional Perlin Noise (a type of gradient noise developed by Ken Perlin). It uses [white~] as a noise source into a sample and hold function and generates smoothened functions according to a frequency value in hertz (values under 0 and above nyquist are aliased).
+[perlin~] is an abstraction that implements 1-dimensional Perlin Noise (a type of gradient noise developed by Ken Perlin). It uses [white~] as a noise source into a sample and hold function and generates smoothened functions according to a frequency value in Hz (values under 0 and above nyquist are aliased).
 

--- a/Resources/Documentation/ELSE/phasor.md
+++ b/Resources/Documentation/ELSE/phasor.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Triggers and Clocks, Envelopes and LFOs
 
 arguments:
-- description: frequency in hertz
+- description: frequency in Hz
   type: float
   default: 0
 - description: initial phase offset
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float
     description: phase sync (resets internal phase)

--- a/Resources/Documentation/ELSE/pic.md
+++ b/Resources/Documentation/ELSE/pic.md
@@ -43,11 +43,11 @@ methods:
   - type: set <symbol>
     description: same as open, but pd doesn't ask to save changes
   - type: latch <float>
-    description: non-zero sets to latch mode
+    description: non-0 sets to latch mode
   - type: outline <float>
-    description: non zero sets to outline mode
+    description: non-0 sets to outline mode
   - type: size <float>
-    description: non zero sets to report size mode
+    description: non-0 sets to report size mode
   - type: send <symbol>
     description: sets a send symbol
   - type: receive <symbol>

--- a/Resources/Documentation/ELSE/pimp.md
+++ b/Resources/Documentation/ELSE/pimp.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Signal Generators
 
 arguments:
-- description: frequency in hertz
+- description: frequency in Hz
   type: float
   default: 0
 - description: initial phase offset
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float
     description: phase sync (resets internal phase)

--- a/Resources/Documentation/ELSE/pimp~.md
+++ b/Resources/Documentation/ELSE/pimp~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default:
 - type: float
   description: initial phase offset
@@ -18,7 +18,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float/signal
     description: phase sync (resets internal phase)

--- a/Resources/Documentation/ELSE/player~.md
+++ b/Resources/Documentation/ELSE/player~.md
@@ -25,9 +25,9 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: non-zero plays, <0> stops
+    description: non-0 plays, <0> stops
   - type: bang
-    description: play (same as non-zero)
+    description: play (same as non-0)
 
 outlets:
   nth:
@@ -65,7 +65,7 @@ methods:
   - type: range <f, f>
     description: sets start and end point proportionally (from 0 to 1)
   - type: speed <float>
-    description: sets playing speed in percentage
+    description: sets playing speed in %
   - type: pos <float>
     description: sets position (from 0 to 1) and starts playing it
   - type: play <f, f, f>
@@ -79,9 +79,9 @@ methods:
   - type: fade <float>
     description: sets fading time in ms (default 0)
   - type: xfade <float>
-    description: non zero sets to crossfading mode (default 0)
+    description: non-0 sets to crossfading mode (default 0)
   - type: loop <float>
-    description: non zero enables looping, <0> disables it (default 0)
+    description: non-0 enables looping, <0> disables it (default 0)
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/pluck~.md
+++ b/Resources/Documentation/ELSE/pluck~.md
@@ -7,7 +7,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: decay time in ms
@@ -21,12 +21,12 @@ inlets:
   - type: signal
     description: trigger (determines the amplitude)
   - type: float
-    description: non zero triggers and sets amplitude
+    description: non-0 triggers and sets amplitude
   - type: bang
     description: triggers with last control amplitude (default 1)
   2nd:
   - type: float/signal
-    description: frequency in hertz (minimum 1)
+    description: frequency in Hz (minimum 1)
   3rd:
   - type: float/signal
     description: decay time in ms
@@ -48,5 +48,5 @@ flags:
 
 ---
 
-[pluck~] is a Karplus-Strong algorithm with a 1st order lowpass filter in the feedback loop. It takes frequency in hertz, a decay time in ms and a cutoff frequency for the filter. It is triggered by signals at zero to non zero transitions or by floats and bangs at control rate.
+[pluck~] is a Karplus-Strong algorithm with a 1st order lowpass filter in the feedback loop. It takes frequency in Hz, a decay time in ms and a cutoff frequency for the filter. It is triggered by signals at zero to non-0 transitions or by floats and bangs at control rate.
 

--- a/Resources/Documentation/ELSE/pmosc~.md
+++ b/Resources/Documentation/ELSE/pmosc~.md
@@ -7,10 +7,10 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: carrier frequency in hertz
+  description: carrier frequency in Hz
   default: 0
 - type: float
-  description: modulation frequency in hertz
+  description: modulation frequency in Hz
   default: 0
 - type: float
   description: modulation index
@@ -22,10 +22,10 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: carrier frequency in hz
+    description: carrier frequency in Hz
   2nd:
   - type: float/signal
-    description: modulation frequency in hz
+    description: modulation frequency in Hz
   3rd:
   - type: float/signal
     description: modulation index

--- a/Resources/Documentation/ELSE/polymetro.md
+++ b/Resources/Documentation/ELSE/polymetro.md
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: non-zero starts, zero stops
+    description: non-0 starts, zero stops
   - type: bang
     description: syncs (restarts count) when polymetro is on
   2nd:

--- a/Resources/Documentation/ELSE/polymetro~.md
+++ b/Resources/Documentation/ELSE/polymetro~.md
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: non-zero starts, zero stops
+    description: non-0 starts, zero stops
   - type: bang
     description: syncs/resets
   2nd:

--- a/Resources/Documentation/ELSE/properties.md
+++ b/Resources/Documentation/ELSE/properties.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Data Management
 
 arguments:
 - type: float
-  description: sets mode, non-zero is "subpatch" mode
+  description: sets mode, non-0 is "subpatch" mode
   default: 0 ("abstraction" mode)
 
 inlets:

--- a/Resources/Documentation/ELSE/pulse.md
+++ b/Resources/Documentation/ELSE/pulse.md
@@ -9,7 +9,7 @@ categories:
 pdcategory: ELSE, Triggers and Clocks
 
 arguments:
-- description: frequency in hertz
+- description: frequency in Hz
   type: float
   default: 0
 - description: pulse width
@@ -22,7 +22,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float
     description: pulse width (from 0 to 1)

--- a/Resources/Documentation/ELSE/pulse~.md
+++ b/Resources/Documentation/ELSE/pulse~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial pulse width
@@ -21,7 +21,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float/signal
     description: pulse width (from 0 to 1)

--- a/Resources/Documentation/ELSE/pvoc.freeze~.md
+++ b/Resources/Documentation/ELSE/pvoc.freeze~.md
@@ -16,7 +16,7 @@ inlets:
     description: input to freeze
   2nd:
   - type: float
-    description: non-zero (re)freezes, 0 unfreezes
+    description: non-0 (re)freezes, 0 unfreezes
 
 outlets:
   1st:

--- a/Resources/Documentation/ELSE/quad~.md
+++ b/Resources/Documentation/ELSE/quad~.md
@@ -9,7 +9,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: nyquist
 - type: float
   description: sets a
@@ -27,7 +27,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
   - type: list
     description: 4 floats sets 'a', 'b', 'c', and y[n-1]
 

--- a/Resources/Documentation/ELSE/rad2hz.md
+++ b/Resources/Documentation/ELSE/rad2hz.md
@@ -1,7 +1,7 @@
 ---
 title: rad2hz
 
-description: radians_per_sample/Hertz conversion
+description: radians_per_sample/Hz conversion
 
 categories:
  - object
@@ -32,5 +32,5 @@ methods:
 draft: false
 ---
 
-Use [rad2hz] to convert a signal representing a frequency in "Radians per Sample" to Hertz. This depends on the patch's sample rate (sr). The conversion formula is;
+Use [rad2hz] to convert a signal representing a frequency in "Radians per Sample" to Hz. This depends on the patch's sample rate (sr). The conversion formula is;
 hz = rad * sr / 2pi

--- a/Resources/Documentation/ELSE/rampnoise~.md
+++ b/Resources/Documentation/ELSE/rampnoise~.md
@@ -10,13 +10,13 @@ pdcategory: ELSE, Random and Noise
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 
 inlets: 
   1st:
   - type: float
-    description: frequency in hertz
+    description: frequency in Hz
 
 outlets:
   1st:
@@ -34,5 +34,5 @@ methods:
 draft: false
 ---
 
-[rampnoise~] is a low frequency (band limited) noise generator with interpolation, therefore it ramps from one random value to another, resulting in random ramps. Random values are between -1 and 1 at a rate in hertz (negative frequencies accepted). Use the seed message if you want a reproducible output.
+[rampnoise~] is a low frequency (band limited) noise generator with interpolation, therefore it ramps from one random value to another, resulting in random ramps. Random values are between -1 and 1 at a rate in Hz (negative frequencies accepted). Use the seed message if you want a reproducible output.
 The [rampnoise~] object produces frequencies limited to a band from 0 up to the frequency it is running. It can go up to the sample rate, and when that happens, it's basically a white noise generator.

--- a/Resources/Documentation/ELSE/rand.hist.md
+++ b/Resources/Documentation/ELSE/rand.hist.md
@@ -58,7 +58,7 @@ methods:
   - type: eq <float>
     description: sets an equal number of occurrences for all elements
   - type: unrepeat
-    description: non-zero sets unrepeat mode
+    description: non-0 sets unrepeat mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/randpulse.md
+++ b/Resources/Documentation/ELSE/randpulse.md
@@ -45,7 +45,7 @@ methods:
   - type: rate <float>
     description: sets refresh rate in ms
   - type: seed <float>
-    description: non-zero sets to random gate value mode
+    description: non-0 sets to random gate value mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/randpulse2.md
+++ b/Resources/Documentation/ELSE/randpulse2.md
@@ -13,7 +13,7 @@ arguments:
   description: density
   default: 0
 - type: float
-  description: non-zero sets to random gate value mode
+  description: non-0 sets to random gate value mode
   default: 0
 
 inlets:
@@ -32,7 +32,7 @@ flags:
 
 methods:
   - type: rand <float>
-    description: non-zero sets to random gate value mode
+    description: non-0 sets to random gate value mode
   - type: seed <float>
     description: - a float sets seed, no float sets a unique internal
 

--- a/Resources/Documentation/ELSE/randpulse2~.md
+++ b/Resources/Documentation/ELSE/randpulse2~.md
@@ -13,7 +13,7 @@ arguments:
   description: density
   default: 0
 - type: float
-  description: non-zero sets to random gate value mode
+  description: non-0 sets to random gate value mode
   default: 0
 
 inlets: 
@@ -32,7 +32,7 @@ flags:
 
 methods:
   - type: rand <float>
-    description: non-zero sets to random gate value mode
+    description: non-0 sets to random gate value mode
   - type: seed <float>
     description: - a float sets seed, no float sets a unique internal
 

--- a/Resources/Documentation/ELSE/randpulse~.md
+++ b/Resources/Documentation/ELSE/randpulse~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Random and Noise, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial pulse width
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float/signal
     description: pulse width (0-1)
@@ -38,7 +38,7 @@ flags:
 
 methods:
   - type: seed <float>
-    description: - non-zero sets to random gate value mode
+    description: - non-0 sets to random gate value mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/rec.md
+++ b/Resources/Documentation/ELSE/rec.md
@@ -20,7 +20,7 @@ inlets:
   - type: play <list>
     description: plays all tracks or tracks from the given list
   - type: speed <float>
-    description: sets playback speed in percentage
+    description: sets playback speed in %
   - type: record <list>
     description: records all tracks or tracks from the given list
   - type: stop <list>

--- a/Resources/Documentation/ELSE/resonant2~.md
+++ b/Resources/Documentation/ELSE/resonant2~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Filters, Effects
 
 arguments:
 - type: float
-  description: center frequency in hertz
+  description: center frequency in Hz
   default: 0
 - type: float
   description: attack time in ms
@@ -25,7 +25,7 @@ inlets:
     description: signal to be filtered or excite the resonator
   2nd:
   - type: float/signal
-    description: central frequency in hertz
+    description: central frequency in Hz
   3rd:
   - type: float/signal
     description: attack time in ms

--- a/Resources/Documentation/ELSE/resonant~.md
+++ b/Resources/Documentation/ELSE/resonant~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Filters, Effects
 
 arguments:
 - type: float
-  description: center frequency in hertz
+  description: center frequency in Hz
   default: 0
 - type: float
   description: resonance
@@ -22,7 +22,7 @@ inlets:
     description: signal to be filtered or excite the resonator
   2nd:
   - type: float/signal
-    description: central frequency in hertz
+    description: central frequency in Hz
   3rd:
   - type: signal
     description: resonance (t60 decay time in ms or Q)

--- a/Resources/Documentation/ELSE/scale2freq.md
+++ b/Resources/Documentation/ELSE/scale2freq.md
@@ -38,5 +38,5 @@ methods:
 
 ---
 
-[scale2freq] gets a scale as a list of cents values, a base/fundamental pitch and outputs a list of frequency in hertz between a minimum and maximum value. Below we use [eqdiv] to generate a scale. Use it to feed values to things like [resonbank~], [oscbank2~] or [pvretune~].
+[scale2freq] gets a scale as a list of cents values, a base/fundamental pitch and outputs a list of frequency in Hz between a minimum and maximum value. Below we use [eqdiv] to generate a scale. Use it to feed values to things like [resonbank~], [oscbank2~] or [pvretune~].
 

--- a/Resources/Documentation/ELSE/sfont~.md
+++ b/Resources/Documentation/ELSE/sfont~.md
@@ -69,7 +69,7 @@ methods:
   - type: info
     description: prints soundfont info on terminal
   - type: verbose <float>
-    description: non-zero sets verbose mode
+    description: non-0 sets verbose mode
   - type: remap <list>
     description: list of 128 pitches in MIDI remaps all keys
   - type: scale <list>

--- a/Resources/Documentation/ELSE/sine~.md
+++ b/Resources/Documentation/ELSE/sine~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial phase offset
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float/signal
     description: phase sync (resets internal phase)

--- a/Resources/Documentation/ELSE/slider2d.md
+++ b/Resources/Documentation/ELSE/slider2d.md
@@ -20,15 +20,15 @@ flags:
 - name: -xrange/-yrange
   description: sets x/y range independently
 - name: -line <f>
-  description: non zero sets line visibility (default: 1)
+  description: non-0 sets line visibility (default: 1)
 - name: -grid <f>
-  description: non zero sets grid visibility (default: 0)
+  description: non-0 sets grid visibility (default: 0)
 - name: -bgcolor <f,f,f>
   description: sets background color (default: 255 255 255)
 - name: -fgcolor <f,f,f>
   description: sets foreground color (default: 0 0 0)
 - name: -init <f>
-  description: non zero sets to init mode (default 0)
+  description: non-0 sets to init mode (default 0)
 
 
 inlets:
@@ -65,10 +65,10 @@ methods:
   description: sets y range
   default:
 - type: line <f>
-  description: - non zero sets line visibility
+  description: - non-0 sets line visibility
   default:
 - type: grid <f>
-  description: non zero sets grid visibility
+  description: non-0 sets grid visibility
   default:
 - type: bgcolor <f,f,f>
   description: sets background color in RGB
@@ -77,7 +77,7 @@ methods:
   description: sets foreground color in RGB
   default:
 - type: init <f>
-  description: non zero sets to init mode
+  description: non-0 sets to init mode
   default:
 
 draft: false

--- a/Resources/Documentation/ELSE/spectrograph~.md
+++ b/Resources/Documentation/ELSE/spectrograph~.md
@@ -14,9 +14,9 @@ flags:
 - name: -size <f>
   description: FFT size (default 1024, min 128)
 - name: -db <f>
-  description: non zero sets to dB amp scale (default linear)
+  description: non-0 sets to dB amp scale (default linear)
 - name: -log <f>
-  description: non zero sets to log frequency scale (default linear)
+  description: non-0 sets to log frequency scale (default linear)
 - name: -dim <f,f>
   description: set horizontal/vertical dimensions (default 300 140)
 - name: -rate <float>
@@ -33,9 +33,9 @@ methods:
   - type: size <f>
     description: sets FFT size
   - type: db <f>
-    description: non zero sets to dB amp scale
+    description: non-0 sets to dB amp scale
   - type: log <f>
-    description: non zero sets to log frequency scale
+    description: non-0 sets to log frequency scale
   - type: dim <f,f>
     description: set horizontal/vertical dimensions
   - type: rate <f>
@@ -45,4 +45,4 @@ methods:
 draft: false
 ---
 
-[spectrograph~] is an abstraction for visualizing FFT amplitudes from 0hz to Nyquist. It uses a hann table for the analysis.
+[spectrograph~] is an abstraction for visualizing FFT amplitudes from 0Hz to Nyquist. It uses a hann table for the analysis.

--- a/Resources/Documentation/ELSE/square~.md
+++ b/Resources/Documentation/ELSE/square~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 - type: float
   description: initial pulse width
@@ -23,7 +23,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float/signal
     description: pulse width (0-1)

--- a/Resources/Documentation/ELSE/sr~.md
+++ b/Resources/Documentation/ELSE/sr~.md
@@ -12,7 +12,7 @@ arguments:
 
 flags:
 - name: -khz
-  description: sets output to frequency in khz
+  description: sets output to frequency in kHz
 - name: -ms
   description: sets output to period ms
 - name: -sec
@@ -32,7 +32,7 @@ methods:
   - type: hz
     description: set and get the sample rate frequency in Hz
   - type: khz
-    description: set and get the sample rate frequency in Khz
+    description: set and get the sample rate frequency in kHz
   - type: ms
     description: set and get the sample rate period in ms
   - type: sec
@@ -41,4 +41,4 @@ methods:
 draft: false
 ---
 
-[sr~] can set the sample rate and also reports the sample rate frequency or period when loading the patch, when receiving a bang or when it changes. The frequency is reported either in hz or khz and the period either in seconds os milliseconds. Unlike [samplerate~], it doesn't report up/down sampling rates. The default output is the sample rate frequency in hertz.
+[sr~] can set the sample rate and also reports the sample rate frequency or period when loading the patch, when receiving a bang or when it changes. The frequency is reported either in Hz or kHz and the period either in seconds os milliseconds. Unlike [samplerate~], it doesn't report up/down sampling rates. The default output is the sample rate frequency in Hz.

--- a/Resources/Documentation/ELSE/standard~.md
+++ b/Resources/Documentation/ELSE/standard~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Random and Noise, Signal Generators
 
 arguments:
 - type: float
-  description: sets frequency in hertz
+  description: sets frequency in Hz
   default: nyquist
 - type: float
   description: sets k
@@ -25,7 +25,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hertz (negative values accepted)
+    description: frequency in Hz (negative values accepted)
   - type: list
     description: 2 floats set x[n-1] and y[n-1], respectively
 
@@ -48,4 +48,4 @@ draft: false
 y[n] = (y[n-1] + k * sin(x[n-1])) % 2pi;
 x[n] = (x[n-1] + y[n]) % 2pi;
 out = (x[n] - pi) / pi;
-The output rate of the equation is given in hertz (default: nyquist).
+The output rate of the equation is given in Hz (default: nyquist).

--- a/Resources/Documentation/ELSE/status.md
+++ b/Resources/Documentation/ELSE/status.md
@@ -23,10 +23,10 @@ inlets:
 outlets:
   1st:
   - type: bang
-    description: if a zero to non-zero transition is detected
+    description: if a zero to non-0 transition is detected
   2nd:
   - type: bang
-    description: if a non-zero to zero transition is detected
+    description: if a non-0 to zero transition is detected
 
 methods:
   - type: change
@@ -35,4 +35,4 @@ methods:
 draft: false
 ---
 
-[status] sends a bang in the left outlet for "zero to non-zero" transitions and a bang in the right outlet for "non-zero to zero" transitions.
+[status] sends a bang in the left outlet for "zero to non-0" transitions and a bang in the right outlet for "non-0 to zero" transitions.

--- a/Resources/Documentation/ELSE/status~.md
+++ b/Resources/Documentation/ELSE/status~.md
@@ -21,12 +21,12 @@ inlets:
 outlets:
   1st:
   - type: signal
-    description: impulse if a zero to non-zero transition is detected
+    description: impulse if a zero to non-0 transition is detected
   2nd:
   - type: signal
-    description: impulse if a non-zero to zero transition is detected
+    description: impulse if a non-0 to zero transition is detected
 
 draft: false
 ---
 
-[status~] is a signal version of [status]. It sends an impulse in the left outlet for "zero to non-zero" transitions and an impulse in the right outlet for "non-zero to zero" transitions.
+[status~] is a signal version of [status]. It sends an impulse in the left outlet for "zero to non-0" transitions and an impulse in the right outlet for "non-0 to zero" transitions.

--- a/Resources/Documentation/ELSE/stepnoise.md
+++ b/Resources/Documentation/ELSE/stepnoise.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Random and Noise
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 
 flags:
@@ -20,7 +20,7 @@ flags:
 inlets:
   1st:
   - type: float
-    description: frequency in hertz up to 100 (negative values accepted)
+    description: frequency in Hz up to 100 (negative values accepted)
 
 outlets:
   1st:

--- a/Resources/Documentation/ELSE/stepnoise~.md
+++ b/Resources/Documentation/ELSE/stepnoise~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Random and Noise, Signal Generators
 
 arguments:
 - type: float
-  description: frequency in hertz
+  description: frequency in Hz
   default: 0
 
 flags:
@@ -21,7 +21,7 @@ flags:
 inlets:
   1st:
   - type: float/signal
-    description: frequency input in hertz
+    description: frequency input in Hz
 
 outlets:
   1st:
@@ -35,5 +35,5 @@ methods:
 draft: false
 ---
 
-[stepnoise~] is a low frequency (band-limited) noise generator without interpolation; therefore, it holds at a random value, resulting in random steps. Random values are between -1 and 1 at a rate in hertz (negative frequencies accepted). Use the seed message if you want a reproducible output.
+[stepnoise~] is a low frequency (band-limited) noise generator without interpolation; therefore, it holds at a random value, resulting in random steps. Random values are between -1 and 1 at a rate in Hz (negative frequencies accepted). Use the seed message if you want a reproducible output.
 The [stepnoise~] object produces frequencies limited to a band from 0 up to the frequency it is running. It can go up to the sample rate, and when that happens, it's basically a white noise generator.

--- a/Resources/Documentation/ELSE/stereo.rev~.md
+++ b/Resources/Documentation/ELSE/stereo.rev~.md
@@ -43,7 +43,7 @@ methods:
   - type: decay <float>
     description: decay time in seconds
   - type: damp <float>
-    description: high frequency damping in hertz
+    description: high frequency damping in Hz
   - type: size <float>
     description: room size (0-1)
   - type: wet <float>

--- a/Resources/Documentation/ELSE/store.md
+++ b/Resources/Documentation/ELSE/store.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Data Management
 
 arguments:
 - type: float
-  description: float - non-zero sets to store elements with the patch
+  description: float - non-0 sets to store elements with the patch
   default: 0
 
 inlets:

--- a/Resources/Documentation/ELSE/suspedal.md
+++ b/Resources/Documentation/ELSE/suspedal.md
@@ -12,7 +12,7 @@ arguments:
 - type: float
   description: float - non-0 turns on the pedal 
   default: 0 - off
-	
+
 inlets:
   1st:
   - type: float

--- a/Resources/Documentation/ELSE/suspedal.md
+++ b/Resources/Documentation/ELSE/suspedal.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, MIDI
 
 arguments:
 - type: float
-  description: float - non-zero turns on the pedal 
+  description: float - non-0 turns on the pedal 
   default: 0 - off
 	
 inlets:
@@ -46,7 +46,7 @@ methods:
   - type: flush 
     description: outputs all held note-off messages
   - type: tonal <float> 
-    description: non zero sets to "tonal" mode
+    description: non-0 sets to "tonal" mode
   - type: retrig <float> 
     description: sets retrigger mode <0, 1, 2 or 3>
   - type: sustain <float> 

--- a/Resources/Documentation/ELSE/tabplayer~.md
+++ b/Resources/Documentation/ELSE/tabplayer~.md
@@ -41,7 +41,7 @@ inlets:
   - type: float
     description: non-0 plays, 0 stops
   - type: bang
-    description: play (same as non-zero)
+    description: play (same as non-0)
   - type: signal
     description: gate on/impulse — starts, gate off — stops (not in trigger mode)
 
@@ -55,7 +55,7 @@ outlets:
 
 methods:
   - type: tr <float>
-    description: non zero sets to trigger mode, zero sets to gate mode
+    description: non-0 sets to trigger mode, zero sets to gate mode
   - type: set <symbol>
     description: sets array name
   - type: start <float>
@@ -69,7 +69,7 @@ methods:
   - type: reset
     description: resets range from 0 to array size
   - type: speed <float>
-    description: sets playing speed in percentage 
+    description: sets playing speed in % 
     default: 100
   - type: play <f, f, f>
     description: start playing, optional <start in ms, end in ms, speed rate>
@@ -80,7 +80,7 @@ methods:
   - type: <resume>
     description: resumes playing after being paused
   - type: loop <float>
-    description: non zero enables looping, <0> disables it 
+    description: non-0 enables looping, <0> disables it 
     default: 0
   - type: fade <float>
     description: sets fade time in ms 

--- a/Resources/Documentation/ELSE/tabreader.md
+++ b/Resources/Documentation/ELSE/tabreader.md
@@ -48,9 +48,9 @@ methods:
     - type: set <symbol>
       description: sets an entire array to be used as a waveform
     - type: index <float>
-      description: non-zero sets index to read from
+      description: non-0 sets index to read from
     - type: loop <float>
-      description: non-zero sets loop mode
+      description: non-0 sets loop mode
     - type: none
       description: sets to no interpolation
     - type: lin

--- a/Resources/Documentation/ELSE/tabreader~.md
+++ b/Resources/Documentation/ELSE/tabreader~.md
@@ -46,7 +46,7 @@ methods:
     - type: set <symbol>
       description: sets an entire array to be used as a waveform
     - type: loop <float>
-      description: non-zero sets loop mode
+      description: non-0 sets loop mode
     - type: none
       description: sets to no interpolation
     - type: lin

--- a/Resources/Documentation/ELSE/tabwriter~.md
+++ b/Resources/Documentation/ELSE/tabwriter~.md
@@ -32,7 +32,7 @@ flags:
 inlets:
   1st:
   - type: float/signals
-    description: non-zero starts recording, 0 stops it
+    description: non-0 starts recording, 0 stops it
   - type: rec
     description: (re)starts recording
   - type: stop
@@ -61,9 +61,9 @@ methods:
   - type: reset
     description: resets start/end from 0 to (current) array's size
   - type: continue <float>
-    description: non-zero continue recording from where it last stopped
+    description: non-0 continue recording from where it last stopped
  - type: loop <float>
-    description: non-zero enables loop recording, 0 disables it
+    description: non-0 enables loop recording, 0 disables it
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/tempo.md
+++ b/Resources/Documentation/ELSE/tempo.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Triggers and Clocks
 
 arguments:
   - type: float
-    description: bpm/hz/ms
+    description: bpm/Hz/ms
     default: 0
   - type: float
     description: swing deviation in %
@@ -23,7 +23,7 @@ flags:
     description: sets time measure to ms
     default: bpm
   - name: -hz
-    description: sets time measure to hertz
+    description: sets time measure to Hz
     default: bpm
   - name: -mul <float>
     description: sets tempo subdivision
@@ -40,7 +40,7 @@ inlets:
     description: sync the metronome
   2nd:
   - type: float
-    description: tempo in ms, hz or bpm
+    description: tempo in ms, Hz or bpm
   3rd:
   - type: float
     description: swing deviation parameter (in %)
@@ -60,7 +60,7 @@ methods:
   - type: ms <f, f>
     description: sets time to ms, optional floats set tempo and swing
   - type: hz <f, f>
-    description: sets time to hz, optional floats set tempo and swing
+    description: sets time to Hz, optional floats set tempo and swing
   - type: bpm <f, f>
     description: sets time to bpm, optional floats set tempo and swing
   - type: seed <float>

--- a/Resources/Documentation/ELSE/tempo~.md
+++ b/Resources/Documentation/ELSE/tempo~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Triggers and Clocks
 
 arguments:
   - type: float
-    description: bpm/hz/ms
+    description: bpm/Hz/ms
     default: 0
   - type: float
     description: swing deviation in %
@@ -23,7 +23,7 @@ flags:
     description: sets time measure to ms
     default: bpm
   - name: -hz
-    description: sets time measure to hz
+    description: sets time measure to Hz
     default: bpm
   - name: -mul <float>
     description: sets multiplier
@@ -59,7 +59,7 @@ methods:
   - type: ms <f, f>
     description: sets time to ms, optional floats set tempo and swing
   - type: hz <f, f>
-    description: sets time to hz, optional floats set tempo and swing
+    description: sets time to Hz, optional floats set tempo and swing
   - type: bpm <f, f>
     description: sets time to bpm, optional floats set tempo and swing
   - type: seed <float>

--- a/Resources/Documentation/ELSE/timed.gate.md
+++ b/Resources/Documentation/ELSE/timed.gate.md
@@ -16,7 +16,7 @@ arguments:
     description: initial gate amplitude
     default: 1
   - type: float
-    description: non-zero sets to retrigger mode
+    description: non-0 sets to retrigger mode
     default: 0
 
 inlets:
@@ -39,7 +39,7 @@ methods:
   - type: ms <float>
     description: gate time in ms
   - type: retrigger <float>
-    description: non-zero sets to retrigger mode
+    description: non-0 sets to retrigger mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/timed.gate~.md
+++ b/Resources/Documentation/ELSE/timed.gate~.md
@@ -16,7 +16,7 @@ arguments:
     description: initial gate amplitude
     default: 1
   - type: float
-    description: non-zero sets to retrigger mode
+    description: non-0 sets to retrigger mode
     default: 0
 
 inlets:
@@ -30,7 +30,7 @@ inlets:
   - type: ms <float>
     description: gate time in ms
   - type: retrigger <float>
-    description: non-zero sets to retrigger mode
+    description: non-0 sets to retrigger mode
   2nd:
   - type: float/signal
     description: gate time in ms
@@ -44,7 +44,7 @@ methods:
   - type: ms <float>
     description: gate time in ms
   - type: retrigger <float>
-    description: non-zero sets to retrigger mode
+    description: non-0 sets to retrigger mode
 
 draft: false
 ---

--- a/Resources/Documentation/ELSE/trig2bang.md
+++ b/Resources/Documentation/ELSE/trig2bang.md
@@ -18,9 +18,9 @@ inlets:
 outlets:
   1st:
   - type: bang
-    description: when detecting zero to non-zero transitions
+    description: when detecting zero to non-0 transitions
 
 draft: false
 ---
 
-[trig2bang] detects zero to non-zero transitions. This can be used to detect and convert triggers (a gate) to a bang.
+[trig2bang] detects zero to non-0 transitions. This can be used to detect and convert triggers (a gate) to a bang.

--- a/Resources/Documentation/ELSE/trig2bang~.md
+++ b/Resources/Documentation/ELSE/trig2bang~.md
@@ -18,9 +18,9 @@ inlets:
 outlets:
   1st:
   - type: bang
-    description: when detecting zero to non-zero transitions
+    description: when detecting zero to non-0 transitions
 
 draft: false
 ---
 
-[trig2bang~] detects zero to non-zero transitions. This can be used to detect and convert trigger signals (impulses and gate) to a bang.
+[trig2bang~] detects zero to non-0 transitions. This can be used to detect and convert trigger signals (impulses and gate) to a bang.

--- a/Resources/Documentation/ELSE/trighold~.md
+++ b/Resources/Documentation/ELSE/trighold~.md
@@ -25,4 +25,4 @@ outlets:
 draft: false
 ---
 
-[trighold~] holds a trigger value. A trigger happens when a transition from 0 to non-zero occurs.
+[trighold~] holds a trigger value. A trigger happens when a transition from 0 to non-0 occurs.

--- a/Resources/Documentation/ELSE/tri~.md
+++ b/Resources/Documentation/ELSE/tri~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
   - type: float
-    description: frequency in hertz
+    description: frequency in Hz
     default: 0
   - type: float
     description: initial phase offset
@@ -19,7 +19,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float/signal
     description: phase sync (resets internal phase)

--- a/Resources/Documentation/ELSE/vibrato~.md
+++ b/Resources/Documentation/ELSE/vibrato~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Effects
 
 arguments:
   - type: float
-    description: rate in hertz 
+    description: rate in Hz 
     default: 0
   - type: float
     description: transposition depth in cents 

--- a/Resources/Documentation/ELSE/voices.md
+++ b/Resources/Documentation/ELSE/voices.md
@@ -13,7 +13,7 @@ arguments:
     description: sets number of voices 
     default: 1
   - type: float
-    description: non zero sets voice stealing
+    description: non-0 sets voice stealing
     default: 0
 
 flags:
@@ -49,7 +49,7 @@ methods:
   - type: offset <float>
     description: sets index offset (in the context of "list" mode)
   - type: retrig <float>
-    description: non zero sets to retrigger mode
+    description: non-0 sets to retrigger mode
   - type: clear
     description: clears memory without output
   - type: flush

--- a/Resources/Documentation/ELSE/vsaw~.md
+++ b/Resources/Documentation/ELSE/vsaw~.md
@@ -10,7 +10,7 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
   - type: float
-    description: frequency in hertz 
+    description: frequency in Hz 
     default: 0
   - type: float
     description: initial width
@@ -22,7 +22,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: frequency in hz
+    description: frequency in Hz
   2nd:
   - type: float/signal
     description: pulse width (from 0 to 1)

--- a/Resources/Documentation/ELSE/wavetable~.md
+++ b/Resources/Documentation/ELSE/wavetable~.md
@@ -22,7 +22,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: sets frequency in hertz
+    description: sets frequency in Hz
 
   2nd:
   - type: float/signal

--- a/Resources/Documentation/ELSE/xmod2~.md
+++ b/Resources/Documentation/ELSE/xmod2~.md
@@ -10,13 +10,13 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
   - type: float
-    description: frequency of oscillator 1 in hertz
+    description: frequency of oscillator 1 in Hz
     default: 0
   - type: float
     description: modulation index 1
     default: 0
   - type: float
-    description: frequency of oscillator 2 in hertz
+    description: frequency of oscillator 2 in Hz
     default: 0
   - type: float
     description: modulation index 2

--- a/Resources/Documentation/ELSE/xmod~.md
+++ b/Resources/Documentation/ELSE/xmod~.md
@@ -10,13 +10,13 @@ pdcategory: ELSE, Signal Generators
 
 arguments:
   - type: float
-    description: frequency of oscillator 1 in hertz
+    description: frequency of oscillator 1 in Hz
     default: 0
   - type: float
     description: modulation index 1
     default: 0
   - type: float
-    description: frequency of oscillator 2 in hertz
+    description: frequency of oscillator 2 in Hz
     default: 0
   - type: float
     description: modulation index 2

--- a/Resources/Documentation/cyclone/allpass~.md
+++ b/Resources/Documentation/cyclone/allpass~.md
@@ -1,6 +1,6 @@
 ---
 title: allpass~
-description: all pass filter
+description: allpass filter
 categories:
  - object
 pdcategory: cyclone, Filters

--- a/Resources/Documentation/cyclone/atodb.md
+++ b/Resources/Documentation/cyclone/atodb.md
@@ -22,5 +22,5 @@ methods:
 
 ---
 
-Use [atodb] to convert a linear amplitude value to a deciBel Full Scale (dBFS) equivalent. Negative values convert to -inf as if the input is "0".
+Use [atodb] to convert a linear amplitude value to a deciBel Full Scale (dBFS) equivalent. Negative values convert to -Inf as if the input is "0".
 

--- a/Resources/Documentation/cyclone/bitsafe~.md
+++ b/Resources/Documentation/cyclone/bitsafe~.md
@@ -1,6 +1,6 @@
 ---
 title: bitsafe~
-description: replace nan/inf and denormal signals with 0
+description: replace NaN/Inf and denormal signals with 0
 categories:
  - object
 pdcategory: cyclone, Logic, Signal Math
@@ -8,11 +8,11 @@ arguments:
 inlets:
   1st:
   - type: signal
-    description: input signals to have nan/inf values replaced with 0
+    description: input signals to have NaN/Inf values replaced with 0
 outlets:
   1st:
   - type: signal
-    description: the signal which has 0 values where nan/inf values existed
+    description: the signal which has 0 values where NaN/Inf values existed
 
 ---
 

--- a/Resources/Documentation/cyclone/comment.md
+++ b/Resources/Documentation/cyclone/comment.md
@@ -47,7 +47,7 @@ methods:
   - type: fontface <float>
     description: sets face: 0-normal, 1-bold, 2-italic, 3-bold+italic
   - type: underline <float>
-    description: non zero sets underline
+    description: non-0 sets underline
   - type: textjustification <f>
     description: sets justification (0: left, 1: center, 2: right)
   - type: textcolor <f, f, f>

--- a/Resources/Documentation/cyclone/cycle~.md
+++ b/Resources/Documentation/cyclone/cycle~.md
@@ -17,7 +17,7 @@ arguments:
 inlets:
   1st:
   - type: float/signal
-    description: sets frequency in hertz (negative values allowed)
+    description: sets frequency in Hz (negative values allowed)
   2nd:
   - type: float/signal
     description: phase offset
@@ -35,7 +35,7 @@ flags:
 
 methods:
   - type: frequency <float>
-    description: sets frequency in hertz
+    description: sets frequency in Hz
   - type: phase <float>
     description: sets phase offset
   - type: set

--- a/Resources/Documentation/cyclone/dbtoa.md
+++ b/Resources/Documentation/cyclone/dbtoa.md
@@ -22,5 +22,5 @@ methods:
 
 ---
 
-Use [dbtoa] to convert decibel values to corresponding linear amplitude.
+Use [dbtoa] to convert dB values to corresponding linear amplitude.
 

--- a/Resources/Documentation/cyclone/edge~.md
+++ b/Resources/Documentation/cyclone/edge~.md
@@ -12,12 +12,12 @@ inlets:
 outlets:
   1st:
   - type: bang
-    description: at zero to non-zero transition
+    description: at zero to non-0 transition
   2nd:
   - type: bang
-    description: at non-zero to zero transition
+    description: at non-0 to zero transition
 
 ---
 
-[edge~] detects signal transitions from zero to non-zero and vice versa and reports bangs accordingly.
+[edge~] detects signal transitions from zero to non-0 and vice versa and reports bangs accordingly.
 

--- a/Resources/Documentation/cyclone/lores~.md
+++ b/Resources/Documentation/cyclone/lores~.md
@@ -1,6 +1,6 @@
 ---
 title: lores~
-description: low-pass resonant filter
+description: lowpass resonant filter
 categories:
  - object
 pdcategory: cyclone, Filters

--- a/Resources/Documentation/cyclone/minmax~.md
+++ b/Resources/Documentation/cyclone/minmax~.md
@@ -13,7 +13,7 @@ inlets:
     description: outputs minimum and maximum on float outlets
   2nd:
   - type: signal
-    description: a non-zero value resets minimum and maximum
+    description: a non-0 value resets minimum and maximum
 outlets:
   1st:
   - type: signal

--- a/Resources/Documentation/cyclone/number~.md
+++ b/Resources/Documentation/cyclone/number~.md
@@ -30,9 +30,9 @@ outlets:
 
 flags:
   - name: @monitormode <float>
-    description: nonzero sets monitor mode 
+    description: non-0 sets monitor mode 
   - name: @sigoutmode <float>
-    description: nonzero sets generator mode 
+    description: non-0 sets generator mode 
   - name: @ft1
     description: ramp time
   - name: @interval <float>

--- a/Resources/Documentation/cyclone/onepole~.md
+++ b/Resources/Documentation/cyclone/onepole~.md
@@ -31,7 +31,7 @@ outlets:
 
 methods:
   - type: Hz 
-    description: sets frequency input mode to 'hertz'
+    description: sets frequency input mode to 'Hz'
   - type: linear
     description: sets frequency input mode to 'linear'
   - type: radians

--- a/Resources/Documentation/cyclone/phaseshift~.md
+++ b/Resources/Documentation/cyclone/phaseshift~.md
@@ -39,5 +39,5 @@ methods:
 draft: true
 ---
 
-[phaseshift~] is a 2nd allpass filter, which keeps the gain and only alters the phase from 0 (at 0 hz) to 360º (at the Nyquist frequency). The frequency at which it shifts to 180º is specified as the filter's frequency and the steepness of the curve is determined by the Q parameter (see graph below).
+[phaseshift~] is a 2nd allpass filter, which keeps the gain and only alters the phase from 0 (at 0 Hz) to 360º (at the Nyquist frequency). The frequency at which it shifts to 180º is specified as the filter's frequency and the steepness of the curve is determined by the Q parameter (see graph below).
 In this example, we add the phase shifted signal to the original, which cancels frequencies by phase opposition.

--- a/Resources/Documentation/cyclone/round.md
+++ b/Resources/Documentation/cyclone/round.md
@@ -33,7 +33,7 @@ flags:
 
 methods:
   - type: nearest <float>
-    description: sets to round (0) or truncate (non-zero) mode
+    description: sets to round (0) or truncate (non-0) mode
 
 draft: true
 ---

--- a/Resources/Documentation/cyclone/round~.md
+++ b/Resources/Documentation/cyclone/round~.md
@@ -33,7 +33,7 @@ flags:
 
 methods:
   - type: nearest <float>
-    description: sets to round (0) or truncate (non-zero) mode
+    description: sets to round (0) or truncate (non-0) mode
 
 draft: true
 ---

--- a/Resources/Documentation/cyclone/spike~.md
+++ b/Resources/Documentation/cyclone/spike~.md
@@ -1,7 +1,7 @@
 ---
 title: spike~
 
-description: report zero to non-zero transition intervals
+description: report zero to non-0 transition intervals
 
 categories:
  - object
@@ -28,4 +28,4 @@ outlets:
 draft: true
 ---
 
-[spike~] reports intervals of zero to non-zero transitions from the signal input. The refractory period is set at the second inlet, which defines how soon after detecting a transition the spike~ object will report the next instance.
+[spike~] reports intervals of zero to non-0 transitions from the signal input. The refractory period is set at the second inlet, which defines how soon after detecting a transition the spike~ object will report the next instance.

--- a/Resources/Documentation/cyclone/svf~.md
+++ b/Resources/Documentation/cyclone/svf~.md
@@ -16,8 +16,8 @@ arguments:
   description: Q/resonance (0-1)
   default: 0.01
 - type: symbol
-  description: frequency mode (hz, linear, radians)
-  default: hz
+  description: frequency mode (Hz, linear, radians)
+  default: Hz
 
 inlets:
   1st:
@@ -48,7 +48,7 @@ methods:
  - type: clear
    description: clears the filter in case of a blow-up
  - type: hz
-   description: sets frequency mode to hz 
+   description: sets frequency mode to Hz 
  - type: linear
     description: sets frequency mode to linear
   - type: radians

--- a/Resources/Documentation/cyclone/togedge.md
+++ b/Resources/Documentation/cyclone/togedge.md
@@ -1,7 +1,7 @@
 ---
 title: togedge
 
-description: report zero / non-zero transitions
+description: report zero / non-0 transitions
 
 categories:
  - object
@@ -15,17 +15,17 @@ inlets:
   - type: float
     description: number to check for transitions
   - type: bang
-    description: switches the stored value between 0 and non-zero
+    description: switches the stored value between 0 and non-0
 
 outlets:
   1st:
   - type: bang
-    description: if a zero to non-zero transition is detected
+    description: if a zero to non-0 transition is detected
   2nd:
   - type: bang
-    description: if a non-zero to zero transition is detected
+    description: if a non-0 to zero transition is detected
 
 draft: true
 ---
 
-[togedge] sends a bang in the left outlet for "zero to non-zero" transitions, and a bang in the right outlet for "non-zero to zero" transitions.
+[togedge] sends a bang in the left outlet for "zero to non-0" transitions, and a bang in the right outlet for "non-0 to zero" transitions.

--- a/Resources/Documentation/cyclone/universal.md
+++ b/Resources/Documentation/cyclone/universal.md
@@ -10,7 +10,7 @@ pdcategory: cyclone, Data Management
 
 arguments:
 - type: float
-  description: non-zero also sends to subpathces
+  description: non-0 also sends to subpathces
   default: 0
 
 inlets: 

--- a/Resources/Documentation/vanilla/abs.md
+++ b/Resources/Documentation/vanilla/abs.md
@@ -12,11 +12,11 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: Input value
+    description: input value
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/abs~.md
+++ b/Resources/Documentation/vanilla/abs~.md
@@ -11,14 +11,14 @@ see_also:
 inlets:
   1st:
   - type: signal
-    description: Input for absolute value
+    description: input for absolute value
 outlets:
   1st:
   - type: signal
-    description: Absolute value
+    description: absolute value
 arguments:
   - type: float 
-    description: Initial value
+    description: initial value
 draft: false
 ---
 The abs~ object passes nonnegative values unchanged, but replaces negative ones with their (positive) inverses.

--- a/Resources/Documentation/vanilla/adc~.md
+++ b/Resources/Documentation/vanilla/adc~.md
@@ -12,10 +12,10 @@ inlets:
 outlets:
   nth:
   - type: signal
-    description: Signal input from sound card
+    description: signal input from sound card
 arguments:
   - type: list
-    description: Set input channels
+    description: set input channels
     default: 1 2
 draft: false
 ---

--- a/Resources/Documentation/vanilla/and.md
+++ b/Resources/Documentation/vanilla/and.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 {{< md_include "objects/bitwise-operators.md" >}}

--- a/Resources/Documentation/vanilla/andand.md
+++ b/Resources/Documentation/vanilla/andand.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/append.md
+++ b/Resources/Documentation/vanilla/append.md
@@ -10,21 +10,21 @@ see_also:
 - scalar
 - struct
 - element  
-pdcategory: vanilla, Data Management, UI
+pdcategory: vanilla, Data Structures, UI
 last_update: '0.47'
 inlets:
   1st:
   - type: set <symbol, symbol>
     description: if none or just one field is given, you can use 'set' to set struct name and field
   - type: float
-    description: set field value and append new Data Structure
+    description: set field value and append new data structure
   2nd:
   - type: pointer
-    description: a pointer to the Data Structure to add
+    description: a pointer to the data structure to add
 outlets:
   1st:
   - type: pointer
-    description: a pointer to added Data Structure
+    description: a pointer to added data structure
 arguments:
 - type: symbol
   description: set template name

--- a/Resources/Documentation/vanilla/array-size.md
+++ b/Resources/Documentation/vanilla/array-size.md
@@ -20,10 +20,10 @@ arguments:
   default: none
   type: symbol
 flags:
-- description: struct name and field name of main structure
-  flag: -s <symbol, symbol>
-- description: struct name and field name of element structure
-  flag: -f <symbol, symbol>
+- name: -s <symbol, symbol>
+  description: struct name and field name of main structure
+- name: -f <symbol, symbol>
+  description: struct name and field name of element structure
 inlets:
   1st:
   - type: bang

--- a/Resources/Documentation/vanilla/array-sum.md
+++ b/Resources/Documentation/vanilla/array-sum.md
@@ -49,4 +49,4 @@ flags:
 - name: -f <symbol, symbol>
   description: struct name and field name of element structure
 ---
-output the sum of the array or a range selecion
+output the sum of the array or a range selection

--- a/Resources/Documentation/vanilla/atan.md
+++ b/Resources/Documentation/vanilla/atan.md
@@ -1,6 +1,6 @@
 ---
 title: atan
-description: arctangens function
+description: arctangent function
 categories:
 - object
 pdcategory: vanilla, Data Math
@@ -12,11 +12,11 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: Input value
+    description: input value
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 Unlike the signal version cos~, control-rate trigonometric functions take inputs in radians.

--- a/Resources/Documentation/vanilla/atan2.md
+++ b/Resources/Documentation/vanilla/atan2.md
@@ -1,6 +1,6 @@
 ---
 title: atan2
-description: 2-argument arctangens function
+description: 2-argument arctangent function
 categories:
 - object
 pdcategory: vanilla, Data Math
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 The atan2 version takes an (x, y

--- a/Resources/Documentation/vanilla/bag.md
+++ b/Resources/Documentation/vanilla/bag.md
@@ -25,6 +25,6 @@ outlets:
     description: the stored values on flush message
 draft: false
 ---
-The bag object adds a value to or removes it from a collection of numbers depending on the flag. The left inlet takes the value and the right inlet takes the flag. If the flag is true (nonzero), the value is added to the collection and removed otherwise. The example here takes a list input, which gets spread at inlets (as is common in Pd).
+The bag object adds a value to or removes it from a collection of numbers depending on the flag. The left inlet takes the value and the right inlet takes the flag. If the flag is true (non-0), the value is added to the collection and removed otherwise. The example here takes a list input, which gets spread at inlets (as is common in Pd).
 
 The collection may have many copies of the same value. You can output the collection (and empty it) with a "flush" message, or just empty it with "clear." You can use this to mimic a sustain pedal, for example.

--- a/Resources/Documentation/vanilla/bng.md
+++ b/Resources/Documentation/vanilla/bng.md
@@ -16,7 +16,7 @@ methods:
 - type: flashtime <float, float>
   description: set minimum and maximum flash time in ms
 - type: init <float>
-  description: non zero sets to init mode
+  description: non-0 sets to init mode
 - type: label <symbol>
   description: sets label symbol
 - type: label_font <float, float>

--- a/Resources/Documentation/vanilla/bob~.md
+++ b/Resources/Documentation/vanilla/bob~.md
@@ -28,7 +28,7 @@ inlets:
     description: post internal state and parameters on Pd's window
   2nd:
   - type: float/signal
-    description: resonant or cutoff frequency in hertz
+    description: resonant or cutoff frequency in Hz
   3rd:
   - type: float/signal
     description: resonance

--- a/Resources/Documentation/vanilla/bob~.md
+++ b/Resources/Documentation/vanilla/bob~.md
@@ -31,7 +31,7 @@ inlets:
     description: resonant or cutoff frequency in hertz
   3rd:
   - type: float/signal
-    description: resonannce
+    description: resonance
 outlets:
   1st:
   - type: signal

--- a/Resources/Documentation/vanilla/bonk~.md
+++ b/Resources/Documentation/vanilla/bonk~.md
@@ -46,13 +46,13 @@ methods:
   - type: minlevel <float>
     description: set minimum "velocity" to output (ignore quieter notes)
   - type: spew <float>
-    description: nonzero turns spew mode on, zero sets it off
+    description: non-0 turns spew mode on, zero sets it off
   - type: useloudness <float>
-    description: nonzero sets to alternative loudness units (experimental)
+    description: non-0 sets to alternative loudness units (experimental)
   - type: debug <float>
-    description: nonzero sets to debugging mode
+    description: non-0 sets to debugging mode
   - type: print <float>
-    description: print out settings, templates and filter bank settings for nonzero
+    description: print out settings, templates and filter bank settings for non-0
   - type: debounce <float>
     description: set minimum time (in msec) between attacks in learn mode
   - type: learn <float>

--- a/Resources/Documentation/vanilla/bonk~.md
+++ b/Resources/Documentation/vanilla/bonk~.md
@@ -52,7 +52,7 @@ methods:
   - type: debug <float>
     description: nonzero sets to debugging mode
   - type: print <float>
-    description: print out settings, templates and filterbank settings for nonzero
+    description: print out settings, templates and filter bank settings for nonzero
   - type: debounce <float>
     description: set minimum time (in msec) between attacks in learn mode
   - type: learn <float>

--- a/Resources/Documentation/vanilla/bp~.md
+++ b/Resources/Documentation/vanilla/bp~.md
@@ -17,7 +17,7 @@ last_update: '0.46'
 inlets:
   1st:
   - type: signal
-    description: input signal to be filtered. 
+    description: input signal to be filtered
   - type: clear
     description: clear filter's memory
   2nd:
@@ -25,7 +25,7 @@ inlets:
     description: center frequency in Hz
   3rd:
   - type: float
-    description:  Q (controls bandwidth).  	
+    description:  Q (controls bandwidth)
 outlets:
   1st:
   - type: signal

--- a/Resources/Documentation/vanilla/choice.md
+++ b/Resources/Documentation/vanilla/choice.md
@@ -18,7 +18,7 @@ outlets:
   1st:
   - type: float
     description: index of best match (from zero)
-argumets:
+arguments:
 - type: float
   description: non zero avoids repeated output 
   default: 0

--- a/Resources/Documentation/vanilla/choice.md
+++ b/Resources/Documentation/vanilla/choice.md
@@ -20,12 +20,12 @@ outlets:
     description: index of best match (from zero)
 arguments:
 - type: float
-  description: non zero avoids repeated output 
+  description: non-0 avoids repeated output 
   default: 0
 draft: false
 ---
 The choice object holds a list of vectors, each having up to ten elements. When sent a list of numbers, it outputs the index of the known vector that matches most closely. The quality of the match is the dot product of the two vectors after normalizing them, i.e., the vector whose direction is closest to that of the input wins.
 
-If given a nonzero creation argument, choice tries to avoid repetitious outputs by weighting less recently output vectors preferentially.
+If given a non-0 creation argument, choice tries to avoid repetitious outputs by weighting less recently output vectors preferentially.
 
 You can use this to choose interactively between a number of behaviors depending on their attributes. For example, you might have stored a number of melodies, of which some are syncopated, some chromatic, some are more than 100 years old, some are bugle calls, and some are Christmas carols. You could then ask to find a syncopated bugle call (1, 0, 0, 1, 0

--- a/Resources/Documentation/vanilla/clip.md
+++ b/Resources/Documentation/vanilla/clip.md
@@ -21,7 +21,7 @@ inlets:
   - type: float
     description: number to clip
   - type: bang
-    description: re-clip last incoming number between the two limits
+    description: re-clip last incoming number
   2nd:
   - type: float
     description: set lower limit

--- a/Resources/Documentation/vanilla/complex-mod~.md
+++ b/Resources/Documentation/vanilla/complex-mod~.md
@@ -16,7 +16,7 @@ inlets:
     description: imaginary part of signal input
   3rd:
   - type: float/signal
-    description: frequency shift amount in hz
+    description: frequency shift amount in Hz
 outlets:
   1st:
   - type: signal

--- a/Resources/Documentation/vanilla/complex-mod~.md
+++ b/Resources/Documentation/vanilla/complex-mod~.md
@@ -30,6 +30,6 @@ The complex modulator takes two signals in which it considers to be the real and
 
 This is also known as 'single side band modulation' and relates to ring modulation (which has two sidebands)
 
-The left output is the frquency shifted by the amount of the frequency shift. The right outlet gives us the other side band, which is shifted by the same amount in reverse.
+The left output is the frequency shifted by the amount of the frequency shift. The right outlet gives us the other side band, which is shifted by the same amount in reverse.
 
 (for instance, if the shift is 100, left output shifts the frequency up by 100 and the right shifts it down by 100)

--- a/Resources/Documentation/vanilla/cos.md
+++ b/Resources/Documentation/vanilla/cos.md
@@ -1,6 +1,6 @@
 ---
 title: cos
-description: Cosine function
+description: cosine function
 categories:
 - object
 pdcategory: vanilla, Data Math
@@ -12,11 +12,11 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: Input value
+    description: input value
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 Unlike the signal version cos~, control-rate trigonometric functions take inputs in radians.

--- a/Resources/Documentation/vanilla/cpole~.md
+++ b/Resources/Documentation/vanilla/cpole~.md
@@ -44,4 +44,4 @@ arguments:
   default: 0 0
 draft: false
 ---
-Cpole~ filters a complex audio signal (first two inlets
+cpole~ filters a complex audio signal (first two inlets

--- a/Resources/Documentation/vanilla/czero~.md
+++ b/Resources/Documentation/vanilla/czero~.md
@@ -1,4 +1,4 @@
----
+--
 title: czero~
 description: complex one-zero filter
 categories:
@@ -44,4 +44,4 @@ arguments:
   default: 0 0
 draft: false
 ---
-Czero~ filters a complex audio signal (first two inlets
+czero~ filters a complex audio signal (first two inlets

--- a/Resources/Documentation/vanilla/dbtopow.md
+++ b/Resources/Documentation/vanilla/dbtopow.md
@@ -11,7 +11,7 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: incomming value to be converted
+    description: incoming value to be converted
 outlets:
   1st:
   - type: float

--- a/Resources/Documentation/vanilla/dbtorms.md
+++ b/Resources/Documentation/vanilla/dbtorms.md
@@ -11,7 +11,7 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: incomming value to be converted
+    description: incoming value to be converted
 outlets:
   1st:
   - type: float

--- a/Resources/Documentation/vanilla/declare.md
+++ b/Resources/Documentation/vanilla/declare.md
@@ -6,14 +6,14 @@ categories:
 pdcategory: vanilla, UI, File Management
 last_update: '0.52'
 flags:
-- description: add to search path, relative to the patch or user paths
-  flag: -path <symbol>
-- description: add to search path, relative to Pd (the 'extra' folder)
-  flag: -stdpath <symbol>
-- description: load a library, relative to the patch or user paths
-  flag: -lib <symbol>
-- description: load a library, relative to Pd (the 'extra' folder)
-  flag: -stdlib <symbol>
+- name: -path <symbol>
+  description: add to search path, relative to the patch or user paths
+- name: -stdpath <symbol>
+  description: add to search path, relative to Pd (the 'extra' folder)
+- name: -lib <symbol>
+  description: load a library, relative to the patch or user paths
+- name: -stdlib <symbol>
+  description: load a library, relative to Pd (the 'extra' folder)
 draft: false
 ---
 Compiled external libraries come either as a single binary pack (the "classic" library format) or as a set of separate binaries and/or abstractions. A single binary pack is what we refer to as a 'library' and needs to be pre loaded - whereas external libraries that have separate binaries/abstractions can be loaded by simply adding its directory to the search path. Adding a directory to the path is also needed if you want to load things like audio and text files that are in it.

--- a/Resources/Documentation/vanilla/delread4~.md
+++ b/Resources/Documentation/vanilla/delread4~.md
@@ -19,7 +19,7 @@ outlets:
     description: delayed signal
 arguments:
   - type: symbol
-    description: delay line name. 
+    description: delay line name
 draft: false
 aliases:
 - vd~

--- a/Resources/Documentation/vanilla/delread~.md
+++ b/Resources/Documentation/vanilla/delread~.md
@@ -23,7 +23,7 @@ arguments:
   - type: float
     description: initial delay time in ms 
   default: 0
-. 
+
 draft: false
 ---
-Delread~ and delread4~ objects read from a delay line allocated in a delwrite~ object with the same name. Note that in this help file we're using delay names with "$0" (the patch ID number used to force locality in Pd
+delread~ and delread4~ objects read from a delay line allocated in a delwrite~ object with the same name. Note that in this help file we're using delay names with "$0" (the patch ID number used to force locality in Pd

--- a/Resources/Documentation/vanilla/delwrite~.md
+++ b/Resources/Documentation/vanilla/delwrite~.md
@@ -22,6 +22,6 @@ arguments:
     description: length of delay line in msec (the maximum delay time in read objects)
 draft: false
 ---
-Delread~ and delread4~ objects read from a delay line allocated in a delwrite~ object with the same name. Note that in this help file we're using delay names with "$0" (the patch ID number used to force locality in Pd). You can use more than one delread~ and/or delread4~ objects for the same delwrite~ object. If the specified delay time in delread~/delread4~ is longer than the size of the delay line or less than zero it is clipped to the length of the delay line.
+delread~ and delread4~ objects read from a delay line allocated in a delwrite~ object with the same name. Note that in this help file we're using delay names with "$0" (the patch ID number used to force locality in Pd). You can use more than one delread~ and/or delread4~ objects for the same delwrite~ object. If the specified delay time in delread~/delread4~ is longer than the size of the delay line or less than zero it is clipped to the length of the delay line.
 
 In case the delwrite~ runs later in the DSP loop than the delread~ or delread4~ objects, the delay is constrained below by one vector length (usually 64 samples).

--- a/Resources/Documentation/vanilla/div.md
+++ b/Resources/Documentation/vanilla/div.md
@@ -1,6 +1,6 @@
 ---
 title: div
-description: Divide numbers
+description: divide numbers
 categories:
 - object
 pdcategory: vanilla, Data Math
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 div and mod do integer division, where div outputs the integer quotient and mod outputs the remainder (modulus

--- a/Resources/Documentation/vanilla/env~.md
+++ b/Resources/Documentation/vanilla/env~.md
@@ -20,5 +20,5 @@ arguments:
   default: 1024
   - type: float
     description: period in samples per analysis 
-    default: half the wondow size
+    default: half the window size
 ---

--- a/Resources/Documentation/vanilla/eq.md
+++ b/Resources/Documentation/vanilla/eq.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 {{< md_include "objects/relational-operators.md" >}}

--- a/Resources/Documentation/vanilla/exp.md
+++ b/Resources/Documentation/vanilla/exp.md
@@ -12,11 +12,11 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: Input value
+    description: input value
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/expr-family.md
+++ b/Resources/Documentation/vanilla/expr-family.md
@@ -136,8 +136,8 @@ The **fexpr~** object provides a flexible mechanism for building FIR and IIR fil
 
 |Functions |# of Args |Description|
 |:---|:---|:--- |
-|mtof() |1 |convert MIDI pitch to frequency in hertz|
-|ftom() |1 |convert frequency in hertz to MIDI pitch|
+|mtof() |1 |convert MIDI pitch to frequency in Hz|
+|ftom() |1 |convert frequency in Hz to MIDI pitch|
 |dbtorms() |1 |convert db to rms|
 |rmstodb() |1 |convert rms to db|
 |powtodb() |1 |convert power to db|

--- a/Resources/Documentation/vanilla/file-copy.md
+++ b/Resources/Documentation/vanilla/file-copy.md
@@ -26,10 +26,10 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
 inlets:
   1st:
   - type: list

--- a/Resources/Documentation/vanilla/file-delete.md
+++ b/Resources/Documentation/vanilla/file-delete.md
@@ -26,16 +26,14 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
 inlets:
   1st:
   - type: symbol
     description: file or directory to be deleted
-  - type: verbose <float>
-    description: set verbosity on or off
 outlets:
   1st:
   - type: symbol
@@ -43,6 +41,9 @@ outlets:
   2nd:
   - type: bang
     description: if an error occurs
+methods:
+  - type: verbose <float>
+    description: set verbosity on or off
 draft: false
 ---
 NOTE: deleting destroys data. there is no confirmation dialog or anything of that kind.

--- a/Resources/Documentation/vanilla/file-glob.md
+++ b/Resources/Documentation/vanilla/file-glob.md
@@ -26,24 +26,24 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
 inlets:
   1st:
   - type: symbol
     description: pattern to be found
-  - type: verbose <float>
-    description: set verbosity on or off
 outlets:
   1st:
   - type: list
-    description: found files/directories as a path symbol and type (file <0> or directory
-      <1>)
+    description: found files/directories as a path symbol and type (file <0>, directory <1>)
   2nd:
   - type: bang
     description: if nothing is found or an error occurs
+methods:
+  - type: verbose <float>
+    description: set verbosity on or off
 draft: false
 ---
 cross-platform notes on globbing:

--- a/Resources/Documentation/vanilla/file-handle.md
+++ b/Resources/Documentation/vanilla/file-handle.md
@@ -26,26 +26,16 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
-- description: file creation mode (user/group/other permissions) in octal
-  flag: -m
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
+- name: -m
+  description: file creation mode (user/group/other permissions) in octal
 inlets:
   1st:
-  - type: open <symbol>
-    description: open a file
   - type: float
     description: read number of bytes
-  - type: seek <list>
-    description: seek file
-  - type: close
-    description: close file
-  - type: verbose <float>
-    description: set verbosity on or off
-  - type: creationmode <octal>
-    description: restrict permissions of the to-be-created file
   2nd:
   - type: symbol
     description: change the associated file-handle
@@ -55,19 +45,20 @@ outlets:
     description: data bytes
   2nd:
   - type: bang
-    description: if file can't be opened, end of the file is reached or a read error
-      occurred
+    description: if file can't be opened, end of file is reached, or a read error occurred
   - type: seek <float>
     description: seek output
-aliases:
-- file
 methods:
-- description: explicit Read-mode
-  method: open <symbol> r
-- description: open file for writing (Append mode)
-  method: open <symbol> a
-- description: open file for writing (Create (or trunCate) mode)
-  method: open <symbol> c
+  - type: open <symbol>
+    description: open a file
+  - type: seek <list>
+    description: seek file
+  - type: close
+    description: close file
+  - type: verbose <float>
+    description: set verbosity on or off
+  - type: creationmode <octal>
+    description: restrict permissions of the to-be-created file
 draft: false
 ---
 The data you read from or write to a file are lists of bytes, which appear in Pd as lists of numbers from 0 to 255 (using out-of-range numbers of symbols leads to undefined behaviour.) The 2nd inlet of the 'file handle' object is documented in the 'file define' subpatch.

--- a/Resources/Documentation/vanilla/file-isdirectory.md
+++ b/Resources/Documentation/vanilla/file-isdirectory.md
@@ -26,16 +26,14 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
 inlets:
   1st:
   - type: symbol
     description: file or directory name
-  - type: verbose <float>
-    description: set verbosity on or off
 outlets:
   1st:
   - type: float
@@ -43,6 +41,9 @@ outlets:
   2nd:
   - type: bang
     description: if an error occurs
+methods:
+  - type: verbose <float>
+    description: set verbosity on or off
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/file-isfile.md
+++ b/Resources/Documentation/vanilla/file-isfile.md
@@ -26,16 +26,14 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
 inlets:
   1st:
   - type: symbol
     description: file or directory name
-  - type: verbose <float>
-    description: set verbosity on or off
 outlets:
   1st:
   - type: float
@@ -43,6 +41,9 @@ outlets:
   2nd:
   - type: bang
     description: if an error occurs
+methods:
+  - type: verbose <float>
+    description: set verbosity on or off
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/file-join.md
+++ b/Resources/Documentation/vanilla/file-join.md
@@ -1,6 +1,6 @@
 ---
 title: file join
-description: '''join'' a list of components using ''/'' as the separator.'
+description: '''join'' a list of components using ''/'' as the separator'
 categories:
 - object
 pdcategory: vanilla, File Management
@@ -34,8 +34,8 @@ outlets:
   - type: symbol
     description: joined path or file
   2nd:
-  - type: Inactive Outlet!
-    description: null
+  - type: null
+    description: inactive outlet!
 draft: false
 ---
 This objects perform common string operations on filenames. no checks are performed verifying the validity/existence of any path-component.

--- a/Resources/Documentation/vanilla/file-mkdir.md
+++ b/Resources/Documentation/vanilla/file-mkdir.md
@@ -26,20 +26,16 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
-- description: file creation mode (user/group/other permissions) in octal
-  flag: -m
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
+- name: -m
+  description: file creation mode (user/group/other permissions) in octal
 inlets:
   1st:
   - type: symbol
     description: directory to be created
-  - type: verbose <float>
-    description: set verbosity on or off
-  - type: creationmode <octal>
-    description: restrict permissions of the to-be-created file
 outlets:
   1st:
   - type: symbol
@@ -47,6 +43,11 @@ outlets:
   2nd:
   - type: bang
     description: when there's an error creating the directory
+methods:
+  - type: verbose <float>
+    description: set verbosity on or off
+  - type: creationmode <octal>
+    description: restrict permissions of file to be created
 draft: false
 ---
 This ensures that a given directory exists by creating it

--- a/Resources/Documentation/vanilla/file-move.md
+++ b/Resources/Documentation/vanilla/file-move.md
@@ -26,10 +26,10 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
 inlets:
   1st:
   - type: list

--- a/Resources/Documentation/vanilla/file-size.md
+++ b/Resources/Documentation/vanilla/file-size.md
@@ -26,10 +26,10 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
 inlets:
   1st:
   - type: symbol

--- a/Resources/Documentation/vanilla/file-split.md
+++ b/Resources/Documentation/vanilla/file-split.md
@@ -35,7 +35,7 @@ outlets:
     description: list of split components
   2nd:
   - type: symbol/bang
-    description: '''/'' if inputs ends with ''/'' or bang otherwise.'
+    description: '''/'' if inputs ends with ''/'' or bang otherwise'
 draft: false
 ---
 This objects perform common string operations on filenames. no checks are performed verifying the validity/existence of any path-component.

--- a/Resources/Documentation/vanilla/file-stat.md
+++ b/Resources/Documentation/vanilla/file-stat.md
@@ -26,16 +26,14 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
 inlets:
   1st:
   - type: symbol
     description: file or directory name
-  - type: verbose <float>
-    description: set verbosity on or off
 outlets:
   1st:
   - type: anything
@@ -43,6 +41,9 @@ outlets:
   2nd:
   - type: bang
     description: if an error occurs
+methods:
+  - type: verbose <float>
+    description: set verbosity on or off
 draft: false
 ---
 [file stat] queries the filesystem about the given path, and outputs the collected data as a number of routable messages.

--- a/Resources/Documentation/vanilla/file-which.md
+++ b/Resources/Documentation/vanilla/file-which.md
@@ -26,16 +26,14 @@ see_also:
 - file splitext
 - file splitname
 flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
+- name: -q
+  description: set quiet verbosity
+- name: -v
+  description: set loud verbosity
 inlets:
   1st:
   - type: symbol
     description: file to locate using Pd's search-paths
-  - type: verbose <float>
-    description: set verbosity on or off
 outlets:
   1st:
   - type: list
@@ -43,6 +41,9 @@ outlets:
   2nd:
   - type: float
     description: when there's an error creating the directory
+methods:
+  - type: verbose <float>
+    description: set verbosity on or off
 draft: false
 ---
 [file which] tries to locate the file in using Pd's search-paths and returns the resolved path.

--- a/Resources/Documentation/vanilla/file.md
+++ b/Resources/Documentation/vanilla/file.md
@@ -28,49 +28,8 @@ see_also:
 arguments:
 - description: 'sets the function of [file], possible values: handle, define, mkdir,
     which, glob, stat, isfile, isdirectory, size, copy, move, delete, split, join,
-    splitext and splitname. The default value is ''handle''.'
+    splitext and splitname. The default value is ''handle'''
   type: symbol
-flags:
-- description: set quiet verbosity
-  flag: -q
-- description: set loud verbosity
-  flag: -v
-- description: file creation mode (user/group/other permissions) in octal
-  flag: -m
-inlets:
-  1st:
-  - type: open <symbol>
-    description: open a file
-  - type: float
-    description: read number of bytes
-  - type: seek <list>
-    description: seek file
-  - type: close
-    description: close file
-  - type: verbose <float>
-    description: set verbosity on or off
-  - type: creationmode <octal>
-    description: restrict permissions of the to-be-created file
-  2nd:
-  - type: symbol
-    description: change the associated file-handle
-outlets:
-  1st:
-  - type: list
-    description: data bytes
-  2nd:
-  - type: bang
-    description: if file can't be opened, end of the file is reached or a read error
-      occurred
-  - type: seek <float>
-    description: seek output
-methods:
-- description: explicit Read-mode
-  method: open <symbol> r
-- description: open file for writing (Append mode)
-  method: open <symbol> a
-- description: open file for writing (Create (or trunCate) mode)
-  method: open <symbol> c
 draft: false
 ---
 Short for "file handle"

--- a/Resources/Documentation/vanilla/ftom.md
+++ b/Resources/Documentation/vanilla/ftom.md
@@ -11,7 +11,7 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: incomming value to be converted
+    description: incoming value to be converted
 outlets:
   1st:
   - type: float

--- a/Resources/Documentation/vanilla/fudiformat.md
+++ b/Resources/Documentation/vanilla/fudiformat.md
@@ -9,8 +9,8 @@ see_also:
 - fudiparse
 - oscformat
 flags:
-- description: "switches to \u201CUDP\u201D mode"
-  flag: -u
+- name: -u
+  description: switches to "UDP" mode
 inlets:
   1st:
   - type: anything

--- a/Resources/Documentation/vanilla/garray.md
+++ b/Resources/Documentation/vanilla/garray.md
@@ -10,7 +10,7 @@ see_also:
 - namecanvas
 - array
 methods:
-- description: sets values into array, fisty element is starting index (from 0)
+- description: sets values into array, first element is starting index (from 0)
   method: list
 - description: optional float sets a constant value to all indexes 
   default: 0

--- a/Resources/Documentation/vanilla/ge.md
+++ b/Resources/Documentation/vanilla/ge.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 {{< md_include "objects/relational-operators.md" >}}

--- a/Resources/Documentation/vanilla/get.md
+++ b/Resources/Documentation/vanilla/get.md
@@ -16,13 +16,13 @@ last_update: '0.47'
 inlets:
   1st:
   - type: pointer
-    description: pointer to a Data Structure scalar
+    description: pointer to a data structure scalar
   - type: set <symbol, symbol>
     description: set template and field name (if none or just one argument is given)
 outlets:
   nth:
   - type: float/symbol
-    description: field value. 
+    description: field value
 arguments:
 - type: symbol
   description: template name

--- a/Resources/Documentation/vanilla/gt.md
+++ b/Resources/Documentation/vanilla/gt.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 {{< md_include "objects/relational-operators.md" >}}

--- a/Resources/Documentation/vanilla/hip~.md
+++ b/Resources/Documentation/vanilla/hip~.md
@@ -1,6 +1,6 @@
 ---
 title: hip~
-description: one-pole high pass filter
+description: one-pole highpass filter
 categories:
 - object
 see_also:
@@ -33,4 +33,4 @@ arguments:
   default: 0
 draft: false
 ---
-hip~ is a one-pole high pass filter with a specified cutoff frequency. Left (audio
+hip~ is a one-pole highpass filter with a specified cutoff frequency. Left (audio

--- a/Resources/Documentation/vanilla/hip~.md
+++ b/Resources/Documentation/vanilla/hip~.md
@@ -22,11 +22,11 @@ inlets:
     description: clear filter's memory
   2nd:
   - type: float
-    description: rolloff frequency.	
+    description: rolloff frequency
 outlets:
   1st:
   - type: signal
-    description: filtered signal. 
+    description: filtered signal
 arguments:
   - type: float
     description: rolloff frequency in Hz 

--- a/Resources/Documentation/vanilla/hradio.md
+++ b/Resources/Documentation/vanilla/hradio.md
@@ -14,11 +14,11 @@ methods:
 - type: size <float>
   description: sets the GUI size
 - type: orientation <float>
-  description: non zero sets to vertical, zero sets to horizontal
+  description: non-0 sets to vertical, zero sets to horizontal
 - type: number <float>
   description: sets number of cells
 - type: init <float>
-  description: non zero sets to init mode
+  description: non-0 sets to init mode
 - type: label <symbol>
   description: sets label symbol
 - type: label_font <float, float>

--- a/Resources/Documentation/vanilla/hradio.md
+++ b/Resources/Documentation/vanilla/hradio.md
@@ -5,11 +5,11 @@ pdcategory: vanilla, UI
 inlets:
   1st:
   - type: float
-    description: Set and output number
+    description: set and output number
 outlets:
   1st:
   - type: float
-    description: Selected cell number
+    description: selected cell number
 methods:
 - type: size <float>
   description: sets the GUI size

--- a/Resources/Documentation/vanilla/hslider.md
+++ b/Resources/Documentation/vanilla/hslider.md
@@ -14,7 +14,7 @@ methods:
 - type: size <float>
   description: sets the GUI size
 - type: orientation <float>
-  description: non zero sets to vertical, zero sets to horizontal
+  description: non-0 sets to vertical, zero sets to horizontal
 - type: range <float, float>
   description: sets minimum and maximum range
 - type: lin
@@ -22,7 +22,7 @@ methods:
 - type: log
   description: sets mode to logarithmic
 - type: init <float>
-  description: non zero sets to init mode
+  description: non-0 sets to init mode
 - type: label <symbol>
   description: sets label symbol
 - type: label_font <float, float>

--- a/Resources/Documentation/vanilla/hslider.md
+++ b/Resources/Documentation/vanilla/hslider.md
@@ -5,11 +5,11 @@ pdcategory: vanilla, UI
 inlets:
   1st:
   - type: float
-    description: Set and output number
+    description: set and output number
 outlets:
   1st:
   - type: float
-    description: Number box value
+    description: number box value
 methods:
 - type: size <float>
   description: sets the GUI size

--- a/Resources/Documentation/vanilla/le.md
+++ b/Resources/Documentation/vanilla/le.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 {{< md_include "objects/relational-operators.md" >}}

--- a/Resources/Documentation/vanilla/list.md
+++ b/Resources/Documentation/vanilla/list.md
@@ -15,7 +15,7 @@ see_also:
 - list tosymbol
 arguments:
 - description: 'sets the function of [list], possible values: append, prepend, store,
-    split, trim, length, fromsymbol and tosymbol. The default value is ''append''.'
+    split, trim, length, fromsymbol and tosymbol. The default value is ''append'''
   type: symbol
 inlets:
   1st:

--- a/Resources/Documentation/vanilla/log.md
+++ b/Resources/Documentation/vanilla/log.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 As in the signal version log~, log takes a base value via an argument or the right inlet, but it defaults to [e](https://en.wikipedia.org/wiki/E_(mathematical_constant

--- a/Resources/Documentation/vanilla/lop~.md
+++ b/Resources/Documentation/vanilla/lop~.md
@@ -1,6 +1,6 @@
 ---
 title: lop~
-description: one-pole low pass filter
+description: one-pole lowpass filter
 categories:
 - object
 see_also:
@@ -33,4 +33,4 @@ arguments:
   default: 0
 draft: false
 ---
-lop~ is a one-pole low pass filter with a specified rolloff frequency. The left inlet is the incoming audio signal. The right inlet is the cutoff frequency in Hz.
+lop~ is a one-pole lowpass filter with a specified rolloff frequency. The left inlet is the incoming audio signal. The right inlet is the cutoff frequency in Hz.

--- a/Resources/Documentation/vanilla/lop~.md
+++ b/Resources/Documentation/vanilla/lop~.md
@@ -22,11 +22,11 @@ inlets:
     description: clear filter's memory
   2nd:
   - type: float
-    description: rolloff frequency.	
+    description: rolloff frequency
 outlets:
   1st:
   - type: signal
-    description: filtered signal. 
+    description: filtered signal
 arguments:
   - type: float
     description: rolloff frequency in Hz 

--- a/Resources/Documentation/vanilla/lshift.md
+++ b/Resources/Documentation/vanilla/lshift.md
@@ -16,15 +16,15 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---

--- a/Resources/Documentation/vanilla/lt.md
+++ b/Resources/Documentation/vanilla/lt.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 {{< md_include "objects/relational-operators.md" >}}

--- a/Resources/Documentation/vanilla/makefilename.md
+++ b/Resources/Documentation/vanilla/makefilename.md
@@ -5,7 +5,7 @@ categories:
 - object
 pdcategory: vanilla, Data Management, File Management
 arguments:
-- description: format strring with specifiers (%c,  %d,  '%i,  %e,  %E,  %f,  %g,  %G,  %o,  %s,  %u,  %x,  %X
+- description: format string with specifiers (%c,  %d,  '%i,  %e,  %E,  %f,  %g,  %G,  %o,  %s,  %u,  %x,  %X
     and %p)
   type: symbol
 inlets:

--- a/Resources/Documentation/vanilla/makenote.md
+++ b/Resources/Documentation/vanilla/makenote.md
@@ -23,7 +23,7 @@ inlets:
     description: MIDI velocity
   3rd:
   - type: float
-    description: MIDI note duratin in ms
+    description: MIDI note duration in ms
 outlets:
   1st:
   - type: float

--- a/Resources/Documentation/vanilla/max.md
+++ b/Resources/Documentation/vanilla/max.md
@@ -20,16 +20,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/max~.md
+++ b/Resources/Documentation/vanilla/max~.md
@@ -22,14 +22,14 @@ arguments:
 inlets:
   1st:
   - type: signal
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float/signal
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: signal
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 This object combine two signals as above, or, if you give a numeric argument, the right inlet only takes floats (no signals

--- a/Resources/Documentation/vanilla/metro.md
+++ b/Resources/Documentation/vanilla/metro.md
@@ -23,7 +23,7 @@ inlets:
   - type: bang
     description: start the metronome
   - type: float
-    description: non zero starts and zero stops the metronome
+    description: non-0 starts and zero stops the metronome
   2nd:
   - type: float
     description: set metronome time for the next tempo

--- a/Resources/Documentation/vanilla/metro.md
+++ b/Resources/Documentation/vanilla/metro.md
@@ -33,7 +33,7 @@ outlets:
     description: bang at periodic time
 
 methods:
-  - tpye: stop
+  - type: stop
     description: stop the metronome
   - type: tempo <float, symbol>
     description: set tempo value and time unit

--- a/Resources/Documentation/vanilla/min.md
+++ b/Resources/Documentation/vanilla/min.md
@@ -20,16 +20,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/minus.md
+++ b/Resources/Documentation/vanilla/minus.md
@@ -20,16 +20,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/minus~.md
+++ b/Resources/Documentation/vanilla/minus~.md
@@ -22,14 +22,14 @@ arguments:
 inlets:
   1st:
   - type: signal
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float/signal
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: signal
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 This object combine two signals as above, or, if you give a numeric argument, the right inlet only takes floats (no signals

--- a/Resources/Documentation/vanilla/min~.md
+++ b/Resources/Documentation/vanilla/min~.md
@@ -22,14 +22,14 @@ arguments:
 inlets:
   1st:
   - type: signal
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float/signal
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: signal
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 This object combine two signals as above, or, if you give a numeric argument, the right inlet only takes floats (no signals

--- a/Resources/Documentation/vanilla/mod.md
+++ b/Resources/Documentation/vanilla/mod.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 div and mod do integer division, where div outputs the integer quotient and mod outputs the remainder (modulus

--- a/Resources/Documentation/vanilla/mtof.md
+++ b/Resources/Documentation/vanilla/mtof.md
@@ -11,7 +11,7 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: incomming value to be converted
+    description: incoming value to be converted
 outlets:
   1st:
   - type: float

--- a/Resources/Documentation/vanilla/mul.md
+++ b/Resources/Documentation/vanilla/mul.md
@@ -20,16 +20,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/mul~.md
+++ b/Resources/Documentation/vanilla/mul~.md
@@ -22,14 +22,14 @@ arguments:
 inlets:
   1st:
   - type: signal
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float/signal
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: signal
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 This object combine two signals as above, or, if you give a numeric argument, the right inlet only takes floats (no signals

--- a/Resources/Documentation/vanilla/nbx.md
+++ b/Resources/Documentation/vanilla/nbx.md
@@ -20,7 +20,7 @@ methods:
 - type: log
   description: sets mode to logarithmic
 - type: init <float>
-  description: non zero sets to init mode
+  description: non-0 sets to init mode
 - type: log_height <float>
   description: sets vertical range in pixels for the log mode
 - type: label <symbol>

--- a/Resources/Documentation/vanilla/nbx.md
+++ b/Resources/Documentation/vanilla/nbx.md
@@ -9,7 +9,7 @@ inlets:
 outlets:
   1st:
   - type: float
-    description: Number box value
+    description: number box value
 methods:
 - type: size <float>
   description: sets the GUI size

--- a/Resources/Documentation/vanilla/neq.md
+++ b/Resources/Documentation/vanilla/neq.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 {{< md_include "objects/relational-operators.md" >}}

--- a/Resources/Documentation/vanilla/netsend.md
+++ b/Resources/Documentation/vanilla/netsend.md
@@ -19,7 +19,7 @@ inlets:
 outlets:
   1st:
   - type: float
-    description: nonzero if connection is open, zero otherwise
+    description: non-0 if connection is open, zero otherwise
   2nd:
   - type: anything
     description: messages sent back from netreceive objects

--- a/Resources/Documentation/vanilla/openpanel.md
+++ b/Resources/Documentation/vanilla/openpanel.md
@@ -9,7 +9,7 @@ see_also:
 - savepanel
 - pdcontrol
 arguments:
-- description: 'mode: 0 (file, default), 1 (directory), 2 (multiple files).'
+- description: 'mode: 0 (file, default), 1 (directory), 2 (multiple files)'
   type: float
 inlets:
   1st:

--- a/Resources/Documentation/vanilla/or.md
+++ b/Resources/Documentation/vanilla/or.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 {{< md_include "objects/bitwise-operators.md" >}}

--- a/Resources/Documentation/vanilla/oror.md
+++ b/Resources/Documentation/vanilla/oror.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/oscformat.md
+++ b/Resources/Documentation/vanilla/oscformat.md
@@ -29,7 +29,7 @@ methods:
   - type: set <list>
     description: set one or more addresses
   - type: format <symbol>
-    description: characters set format types: 'b' (blob), 'i' (interger), 'f' (float), or 's' (sring)
+    description: characters set format types: 'b' (blob), 'i' (integer), 'f' (float), or 's' (string)
 
 draft: false
 ---

--- a/Resources/Documentation/vanilla/pack.md
+++ b/Resources/Documentation/vanilla/pack.md
@@ -9,13 +9,13 @@ see_also:
 - trigger
 - unpack
 arguments:
-- description: list of types (defining the number of inlets). These can be 'float/f', 'symbol/s', and 'pointer/p'. A number sets a numeric inlet and initializes the value, 'float/f' initialized to 0
+- description: symbols defining types of inlets: float/symbol/pointer (f/s/p). a number sets a numeric inlet and initializes the value. f is initialized to 0
   default: 0 0
   type: list
 inlets:
   1st:
   - type: anything
-    description: message type according to corresponding creation argument. These can be float, symbol, and pointer. The 1st inlet causes an output, and can also match an 'anything' to a symbol
+    description: message type according to corresponding argument (float/symbol/pointer). 1st inlet causes an output, and can match an 'anything' to a symbol
   - type: bang
     description: output the packed list
   nth:

--- a/Resources/Documentation/vanilla/percent.md
+++ b/Resources/Documentation/vanilla/percent.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 div and mod do integer division, where div outputs the integer quotient and mod outputs the remainder (modulus

--- a/Resources/Documentation/vanilla/pipe.md
+++ b/Resources/Documentation/vanilla/pipe.md
@@ -9,9 +9,9 @@ see_also:
 - delay
 - timer
 arguments:
-- description: (optional) symbols sets number of inlets and type (f default,  s,  p)
-    and floats set float type and initial value
+- description: (optional) symbols sets number of inlets and type (f, s, p) and floats set float type and initial value
   type: list
+  default: f
 - description: sets delay time in ms 
   default: 0
   order: last

--- a/Resources/Documentation/vanilla/pique.md
+++ b/Resources/Documentation/vanilla/pique.md
@@ -14,7 +14,7 @@ inlets:
 outlets:
   1st:
   - type: list
-    description: partial index, frequency in hz, amplitude, cosine and sine components
+    description: partial index, frequency in Hz, amplitude, cosine and sine components
 draft: false
 ---
 NOTE: pique is obsolete! consider using [sigmund~]

--- a/Resources/Documentation/vanilla/plus.md
+++ b/Resources/Documentation/vanilla/plus.md
@@ -20,16 +20,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/plus~.md
+++ b/Resources/Documentation/vanilla/plus~.md
@@ -22,14 +22,14 @@ arguments:
 inlets:
   1st:
   - type: signal
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float/signal
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: signal
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 This object combine two signals as above, or, if you give a numeric argument, the right inlet only takes floats (no signals

--- a/Resources/Documentation/vanilla/poly.md
+++ b/Resources/Documentation/vanilla/poly.md
@@ -34,7 +34,7 @@ outlets:
     description: note pitch
   3rd:
   - type: float
-    description: note velocitty
+    description: note velocity
 draft: false
 ---
 The poly object takes a stream of pitch/velocity pairs and outputs triples containing voice number, pitch and velocity. You can pack the output and use the route object to route messages among a bank of voices depending on the first outlet. Another option is to connect it [clone] so you can route to different copies. Poly can be configured to do voice stealing or not (the default.

--- a/Resources/Documentation/vanilla/poly.md
+++ b/Resources/Documentation/vanilla/poly.md
@@ -12,7 +12,7 @@ arguments:
 - description: number of voices 
   default: 1
   type: float
-- description: non-zero sets to voice stealing
+- description: non-0 sets to voice stealing
   type: float
 inlets:
   1st:

--- a/Resources/Documentation/vanilla/pow.md
+++ b/Resources/Documentation/vanilla/pow.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 Pow raises a number on the left inlet to a numeric power (given by the right inlet or argument

--- a/Resources/Documentation/vanilla/print~.md
+++ b/Resources/Documentation/vanilla/print~.md
@@ -15,7 +15,7 @@ inlets:
   - type: bang
     description: print one block on terminal window
   - type: float
-    description: sets and prints number of blocks on terminal window. 
+    description: sets and prints number of blocks on terminal window
 arguments:
 - type: symbol
   description: symbol to distinct one [print~] from another

--- a/Resources/Documentation/vanilla/readsf~.md
+++ b/Resources/Documentation/vanilla/readsf~.md
@@ -13,7 +13,7 @@ inlets:
   - type: open <list>
     description: sets a filename, an onset in samples, header size to skip, number of channels, bytes per sample, and endianness
   - type: float
-    description: nonzero starts playback, zero stops
+    description: non-0 starts playback, zero stops
   - type: print
     description: prints information on Pd's terminal window
 outlets:

--- a/Resources/Documentation/vanilla/receive.md
+++ b/Resources/Documentation/vanilla/receive.md
@@ -11,9 +11,8 @@ see_also:
 - receive~
 - samplerate~
 arguments:
-- description: 'receive name symbol 
-  default:: empty symbol
-'
+- description: receive name symbol 
+  default: empty symbol
   type: symbol
 outlets:
   1st:

--- a/Resources/Documentation/vanilla/rev2~.md
+++ b/Resources/Documentation/vanilla/rev2~.md
@@ -17,13 +17,13 @@ inlets:
     description: level in dB
   3rd:
   - type: float
-    description: liveness (internal feedback percentage)
+    description: liveness (internal feedback %)
   4th:
   - type: float
     description: crossover frequency in Hz
   5th:
   - type: float
-    description: high frequency damping in percentage
+    description: high frequency damping in %
 outlets:
   1st:
   - type: signal
@@ -42,12 +42,12 @@ arguments:
   description: level in dB 
   default: 0
 - type: float
-  description: liveness / internal feedback percentage
+  description: liveness / internal feedback %
   default: 0
 - type: float
   description: crossover frequency in Hz
   default: 3000
 - type: float
-  description: high frequency damping in percentage
+  description: high frequency damping in %
   default: 0
 

--- a/Resources/Documentation/vanilla/rev3~.md
+++ b/Resources/Documentation/vanilla/rev3~.md
@@ -20,13 +20,13 @@ inlets:
     description: level in dB
   4th:
   - type: float
-    description: liveness (internal feedback percentage)
+    description: liveness (internal feedback %)
   5th:
   - type: float
     description: crossover frequency in Hz
   6th:
   - type: float
-    description: high frequency damping in percentage
+    description: high frequency damping in %
 outlets:
   1st:
   - type: signal
@@ -45,12 +45,12 @@ arguments:
   description: level in dB 
   default: 0
 - type: float
-  description: liveness / internal feedback percentage
+  description: liveness / internal feedback %
   default: 0
 - type: float
   description: crossover frequency in Hz
   default: 3000
 - type: float
-  description: high frequency damping in percentage
+  description: high frequency damping in %
   default: 0
 

--- a/Resources/Documentation/vanilla/rmstodb.md
+++ b/Resources/Documentation/vanilla/rmstodb.md
@@ -11,7 +11,7 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: incomming value to be converted
+    description: incoming value to be converted
 outlets:
   1st:
   - type: float

--- a/Resources/Documentation/vanilla/rpole~.md
+++ b/Resources/Documentation/vanilla/rpole~.md
@@ -18,10 +18,6 @@ inlets:
   1st:
   - type: signal
     description: real signal to filter
-  - type: set <float>
-    description: set internal state
-  - type: clear
-    description: clear internal state to zero (same as "set 0")
   2nd:
   - type: signal
     description: filter coefficient
@@ -33,6 +29,11 @@ arguments:
   - type: float
     description: filter coefficient 
   default: 0
+methods:
+  - type: set <float>
+    description: set internal state
+  - type: clear
+    description: clear internal state to zero (same as "set 0")
 draft: false
 ---
 Rpole~ filters an audio signal (left inlet

--- a/Resources/Documentation/vanilla/rshift.md
+++ b/Resources/Documentation/vanilla/rshift.md
@@ -16,16 +16,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 {{< md_include "objects/bitwise-operators.md" >}}

--- a/Resources/Documentation/vanilla/rzero_rev~.md
+++ b/Resources/Documentation/vanilla/rzero_rev~.md
@@ -18,10 +18,6 @@ inlets:
   1st:
   - type: signal
     description: real signal to filter
-  - type: set <float>
-    description: set internal state
-  - type: clear
-    description: clear internal state to zero (same as "set 0")
   2nd:
   - type: signal
     description: filter coefficient
@@ -32,7 +28,12 @@ outlets:
 arguments:
   - type: float
     description: filter coefficient 
-  default: 0
+    default: 0
+methods:
+  - type: set <float>
+    description: set internal state
+  - type: clear
+    description: clear internal state to zero (same as "set 0")
 draft: false
 ---
 Rzero_rev~ filters an audio signal (left inlet

--- a/Resources/Documentation/vanilla/rzero~.md
+++ b/Resources/Documentation/vanilla/rzero~.md
@@ -18,10 +18,6 @@ inlets:
   1st:
   - type: signal
     description: real signal to filter
-  - type: set <float>
-    description: set internal state
-  - type: clear
-    description: clear internal state to zero (same as "set 0")
   2nd:
   - type: signal
     description: filter coefficient
@@ -32,7 +28,12 @@ outlets:
 arguments:
   - type: float
     description: filter coefficient 
-  default: 0
+    default: 0
+methods:
+  - type: set <float>
+    description: set internal state
+  - type: clear
+    description: clear internal state to zero (same as "set 0")
 draft: false
 ---
 Rzero~ filters an audio signal (left inlet

--- a/Resources/Documentation/vanilla/samphold~.md
+++ b/Resources/Documentation/vanilla/samphold~.md
@@ -10,12 +10,6 @@ inlets:
   1st:
   - type: signal
     description: input to be sampled
-  - type: set <float>
-    description: set output value
-  - type: reset <float>
-    description: set last value of right inlet
-  - type: reset
-    description: set last value of right inlet to infinity (forces output)
   2nd:
   - type: signal
     description: control signal (triggers when smaller than previous)	
@@ -23,6 +17,13 @@ outlets:
   1st:
   - type: signal
     description: sampled and held signal
+methods:
+  - type: set <float>
+    description: set output value
+  - type: reset <float>
+    description: set last value of right inlet
+  - type: reset
+    description: set last value of right inlet to infinity (forces output)
 draft: false
 ---
 The samphold~ object samples its left input whenever its right input decreases in value (as a phasor~ does each period, for example.) Both inputs are audio signals.

--- a/Resources/Documentation/vanilla/scalar-define.md
+++ b/Resources/Documentation/vanilla/scalar-define.md
@@ -13,8 +13,6 @@ inlets:
   1st:
   - type: bang
     description: output a pointer to the scalar
-  - type: send <symbol>
-    description: send pointer to a named receive object
 outlets:
   1st:
   - type: pointer
@@ -25,6 +23,9 @@ flags:
 arguments:
 - type: symbol
   description: template name
+methods:
+  - type: send <symbol>
+    description: send pointer to a named receive object
 draft: false
 ---
 create, store, and/or edit one

--- a/Resources/Documentation/vanilla/scalar.md
+++ b/Resources/Documentation/vanilla/scalar.md
@@ -14,8 +14,6 @@ inlets:
   1st:
   - type: bang
     description: output a pointer to the scalar
-  - type: send <symbol>
-    description: send pointer to a named receive object
 outlets:
   1st:
   - type: pointer
@@ -26,6 +24,9 @@ flags:
 arguments:
 - type: symbol
   description: template name
+methods:
+  - type: send <symbol>
+    description: send pointer to a named receive object
 draft: false
 ---
 experimental - doesn't do much yet. This has been included in 0.45 to check that its design will work coherently with the array and text objects

--- a/Resources/Documentation/vanilla/set.md
+++ b/Resources/Documentation/vanilla/set.md
@@ -14,23 +14,23 @@ see_also:
 pdcategory: vanilla, Data Structures
 last_update: '0.47'
 inlets:
-  1st:
-  - type: set <symbol, symbol>
-    description: if none or just one field is given, you can use 'set' to set struct name and field
-  "'n' :number of arguments set 'n' fields and we create 'n' inlets for them.":
+  nth:
   - type: float/symbol
     description: value in a scalar
   2nd:
   - type: pointer
     description: a pointer to the scalar
 flags:
-- name:	"-symbol"
+- name:	-symbol
   description: so you can set symbol values
 arguments:
 - type: symbol
   description: structure name
 - type: list
   description: symbols for field names (each creates an inlet)
+methods:
+  - type: set <symbol, symbol>
+    description: if none or just one field is given, you can use 'set' to set struct name and field
 draft: false
 ---
 "Set" takes a pointer to a scalar in its rightmost inlet. The remaining inlets set numeric fields. Symbols are handled specially, as shown below. Arrays are accessed using the "element" object, and lists using "text" objects. Only the leftmost inlet is "hot".

--- a/Resources/Documentation/vanilla/sin.md
+++ b/Resources/Documentation/vanilla/sin.md
@@ -12,11 +12,11 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: Input value
+    description: input value
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 Unlike the signal version cos~, control-rate trigonometric functions take inputs in radians.

--- a/Resources/Documentation/vanilla/slash.md
+++ b/Resources/Documentation/vanilla/slash.md
@@ -20,16 +20,16 @@ arguments:
 inlets:
   1st:
   - type: bang
-    description: Trigger calculation and output value
+    description: trigger calculation and output value
   - type: float
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/slash~.md
+++ b/Resources/Documentation/vanilla/slash~.md
@@ -22,14 +22,14 @@ arguments:
 inlets:
   1st:
   - type: signal
-    description: Set value on left-hand side and trigger output
+    description: set value on left-hand side and trigger output
   2nd:
   - type: float/signal
-    description: Set value on right-hand side
+    description: set value on right-hand side
 outlets:
   1st:
   - type: signal
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 This object combine two signals as above, or, if you give a numeric argument, the right inlet only takes floats (no signals

--- a/Resources/Documentation/vanilla/slop~.md
+++ b/Resources/Documentation/vanilla/slop~.md
@@ -1,6 +1,6 @@
 ---
 title: slop~
-description: slew-limiting low-pass filter
+description: slew-limiting lowpass filter
 categories:
 - object
 see_also:

--- a/Resources/Documentation/vanilla/slop~.md
+++ b/Resources/Documentation/vanilla/slop~.md
@@ -16,13 +16,13 @@ arguments:
   - type: float
     description: maximum downward slew of linear region 
     default: 0
-  - tpye: float
+  - type: float
     description: asymptotic downward cutoff frequency
     default: 0
-  - tpye: float
+  - type: float
     description: maximum upward slew of linear region
     default: 0
-  - tpye: float
+  - type: float
     description: asymptotic upward cutoff frequency
     default: 0
 inlets:

--- a/Resources/Documentation/vanilla/soundfiler.md
+++ b/Resources/Documentation/vanilla/soundfiler.md
@@ -17,11 +17,11 @@ inlets:
   - type: read <list>
     description: 'sets a filename to open and optionally one or more arrays to load
       channels. `Optional flags`: -wave,  -aiff,  -caf,  -next,  -skip <float>,  -maxsize
-      <float>,  -ascii,  -raw <list>.'
+      <float>,  -ascii,  -raw <list>'
   - type: write <list>
     description: 'sets a filename to write and one or more arrays to specify channels
       `Optional flags`: -wave,  -aiff,  -caf,  -next,  -big,  -little,  -skip <float>,  -nframes
-      <float>,  -ascii,  -normalize,  -rate <float>.'
+      <float>,  -ascii,  -normalize,  -rate <float>'
 outlets:
   1st:
   - type: float

--- a/Resources/Documentation/vanilla/spigot.md
+++ b/Resources/Documentation/vanilla/spigot.md
@@ -14,11 +14,11 @@ inlets:
     description: any message to pass or not
   2nd:
   - type: float
-    description: nonzero to pass messages,  zero to stop them
+    description: non-0 to pass messages,  zero to stop them
 outlets:
   1st:
   - type: anything
     description: any input message if spigot is opened
 draft: false
 ---
-Spigot passes messages from its left inlet to its outlet,  as long as a nonzero number is sent to its right inlet. When its right inlet gets zero,  incoming messages are "blocked" i.e.,  ignored.
+Spigot passes messages from its left inlet to its outlet,  as long as a non-0 number is sent to its right inlet. When its right inlet gets zero,  incoming messages are "blocked" i.e.,  ignored.

--- a/Resources/Documentation/vanilla/spigot.md
+++ b/Resources/Documentation/vanilla/spigot.md
@@ -18,7 +18,7 @@ inlets:
 outlets:
   1st:
   - type: anything
-    description: any input message if spigot is openned
+    description: any input message if spigot is opened
 draft: false
 ---
 Spigot passes messages from its left inlet to its outlet,  as long as a nonzero number is sent to its right inlet. When its right inlet gets zero,  incoming messages are "blocked" i.e.,  ignored.

--- a/Resources/Documentation/vanilla/sqrt.md
+++ b/Resources/Documentation/vanilla/sqrt.md
@@ -12,11 +12,11 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: Input value
+    description: input value
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/stdout.md
+++ b/Resources/Documentation/vanilla/stdout.md
@@ -26,7 +26,7 @@ flags:
 - name: -nf
   description: same as -noflush
 - name: -noflush
-  description: do not flush the output after each message.  
+  description: do not flush the output after each message
 draft: false
 ---
 The 'stdout' object is useful in conjunction with the pd~ object, which starts a Pd sub-process. Messages sent to the sub-process standard output appear on the left output of the pd~ object in the owning process. This might also be useful in other situations. Note that there's no corresponding "stdin" object - there seems to be no one canonical way such a thing should act.

--- a/Resources/Documentation/vanilla/switch~.md
+++ b/Resources/Documentation/vanilla/switch~.md
@@ -12,7 +12,7 @@ last_update: '0.43'
 inlets:
   1st:
   - type: float
-    description: nonzero turns DSP on, zero turns DSP off
+    description: non-0 turns DSP on, zero turns DSP off
   - type: bang
     description: when turned off, computes just one DSP cycle
 

--- a/Resources/Documentation/vanilla/tabplay~.md
+++ b/Resources/Documentation/vanilla/tabplay~.md
@@ -33,7 +33,7 @@ outlets:
     description: bang when finished playing the table
 arguments:
   - type: symbol
-    description: sets table name with the sample. 
+    description: sets table name with the sample
 draft: false
 ---
 The tabplay~ object plays a sample, or part of one, with no transposition or interpolation. It is cheaper than tabread4~ and there are none of tabread4~'s interpolation artifacts.

--- a/Resources/Documentation/vanilla/tabread4.md
+++ b/Resources/Documentation/vanilla/tabread4.md
@@ -8,7 +8,7 @@ arguments:
 inlets:
   1st:
   - type: float
-    description: sets table index and output its value with interpoation
+    description: sets table index and output its value with interpolation
 outlets:
   1st:
   - type: float

--- a/Resources/Documentation/vanilla/tabread4~.md
+++ b/Resources/Documentation/vanilla/tabread4~.md
@@ -10,7 +10,7 @@ arguments:
 inlets:
   1st:
   - type: signal
-    description: sets table index and output its value with interpoation
+    description: sets table index and output its value with interpolation
   2nd:
   - type: float
     description: sets table onset

--- a/Resources/Documentation/vanilla/tabread~.md
+++ b/Resources/Documentation/vanilla/tabread~.md
@@ -18,15 +18,16 @@ inlets:
   1st:
   - type: signal
     description: sets table index and output its value
-  - type: set <symbol>
-    description: set the table name
 outlets:
   1st:
   - type: signal
     description: value of index input
 arguments:
   - type: symbol
-    description: sets table name with the sample. 
+    description: sets table name with the sample
+methods:
+  - type: set <symbol>
+    description: set the table name
 draft: false
 ---
 Tabread~ looks up values out of the named array. Incoming values are truncated to the next lower integer, and values out of bounds get the nearest (first or last) point.

--- a/Resources/Documentation/vanilla/tan.md
+++ b/Resources/Documentation/vanilla/tan.md
@@ -12,11 +12,11 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: Input value
+    description: input value
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 Unlike the signal version cos~, control-rate trigonometric functions take inputs in radians.

--- a/Resources/Documentation/vanilla/text-define.md
+++ b/Resources/Documentation/vanilla/text-define.md
@@ -23,8 +23,8 @@ arguments:
 - description: set text name
   type: symbol
 flags:
-- description: saves/keeps the contents of the text with the patch
-  flag: -k
+- name: -k
+  description: saves/keeps the contents of the text with the patch
 inlets:
   1st:
   - type: bang

--- a/Resources/Documentation/vanilla/text-delete.md
+++ b/Resources/Documentation/vanilla/text-delete.md
@@ -24,8 +24,8 @@ arguments:
   default: none
   type: symbol
 flags:
-- description: struct name and field name of main structure
-  flag: -s <symbol, symbol>
+- name: -s <symbol, symbol>
+  description: struct name and field name of main structure
 
 inlets:
   1st:

--- a/Resources/Documentation/vanilla/text-fromlist.md
+++ b/Resources/Documentation/vanilla/text-fromlist.md
@@ -20,13 +20,12 @@ see_also:
 - text search
 - text sequence
 arguments:
-- description: 'text name if no flags are given 
-  default:: none
-.'
+- description: text name if no flags are given 
+  default: none
   type: symbol
 flags:
-- description: struct name and field name of main structure
-  flag: -s <symbol, symbol>
+- name: -s <symbol, symbol>
+  description: struct name and field name of main structure
 inlets:
   1st:
   - type: list

--- a/Resources/Documentation/vanilla/text-search.md
+++ b/Resources/Documentation/vanilla/text-search.md
@@ -20,16 +20,15 @@ see_also:
 - text
 - text sequence
 arguments:
-- description: 'text name if no flags are given 
-  default:: none
-.'
+- description: text name if no flags are given 
+  default: none
   type: symbol
 - description: search field number optionally preceded by '>'. '>=', '<', '<=', or
     'near'
   type: list
 flags:
-- description: struct name and field name of main structure
-  flag: -s <symbol, symbol>
+- name: -s <symbol, symbol>
+  description: struct name and field name of main structure
 inlets:
   1st:
   - type: list

--- a/Resources/Documentation/vanilla/text-size.md
+++ b/Resources/Documentation/vanilla/text-size.md
@@ -20,13 +20,12 @@ see_also:
 - text search
 - text sequence
 arguments:
-- description: 'text name if no flags are given 
-  default:: none
-.'
+- description: text name if no flags are given 
+  default: none
   type: symbol
 flags:
-- description: struct name and field name of main structure
-  flag: -s <symbol, symbol>
+- name: -s <symbol, symbol>
+  description: struct name and field name of main structure
 inlets:
   1st:
   - type: bang

--- a/Resources/Documentation/vanilla/text-tolist.md
+++ b/Resources/Documentation/vanilla/text-tolist.md
@@ -20,13 +20,12 @@ see_also:
 - text search
 - text sequence
 arguments:
-- description: 'text name if no flags are given 
-  default:: none
-.'
+- description: text name if no flags are given 
+  default: none
   type: symbol
 flags:
-- description: struct name and field name of main structure
-  flag: -s <symbol, symbol>
+- name: -s <symbol, symbol>
+  description: struct name and field name of main structure
 inlets:
   1st:
   - type: bang

--- a/Resources/Documentation/vanilla/text.md
+++ b/Resources/Documentation/vanilla/text.md
@@ -21,15 +21,23 @@ see_also:
 - text sequence
 arguments:
 - description: 'sets the function of [text], possible values: define, get, set, insert,
-    delete, size, tolist, fromlist, search and sequence. The default value is ''define''.'
+    delete, size, tolist, fromlist, search and sequence. The default value is ''define'''
   type: symbol
 flags:
-- description: saves/keeps the contents of the text with the patch
-  flag: -k
+- name: -k
+  description: saves/keeps the contents of the text with the patch
 inlets:
   1st:
   - type: bang
     description: output a pointer to the scalar containing the text
+outlets:
+  1st:
+  - type: pointer
+    description: a pointer to the scalar containing the array
+  2nd:
+  - type: anything
+    description: outputs "updated" when text changes
+methods:
   - type: clear
     description: clear contents of the text
   - type: send <symbol>
@@ -44,13 +52,6 @@ inlets:
     description: open text window
   - type: close
     description: closes the text window
-outlets:
-  1st:
-  - type: pointer
-    description: a pointer to the scalar containing the array
-  2nd:
-  - type: anything
-    description: outputs "updated" when text changes
 draft: false
 ---
 

--- a/Resources/Documentation/vanilla/tgl.md
+++ b/Resources/Documentation/vanilla/tgl.md
@@ -7,7 +7,7 @@ inlets:
   - type: bang
     description: Flip toggle value
   - type: float
-    description: Enables toggle if non-zero
+    description: Enables toggle if non-0
 outlets:
   1st:
   - type: float
@@ -18,7 +18,7 @@ methods:
 - type: flashtime <float, float>
   description: set minimum and maximum flash time in ms
 - type: init <float>
-  description: non zero sets to init mode
+  description: non-0 sets to init mode
 - type: label <symbol>
   description: sets label symbol
 - type: label_font <float, float>

--- a/Resources/Documentation/vanilla/threshold~.md
+++ b/Resources/Documentation/vanilla/threshold~.md
@@ -16,7 +16,7 @@ inlets:
     description: set different values for the 4 arguments
   2nd:
   - type: float
-    description: nonzero sets internal state to 'high', 'low' otherwise
+    description: non-0 sets internal state to 'high', 'low' otherwise
 outlets:
   1st:
   - type: bang

--- a/Resources/Documentation/vanilla/throw~.md
+++ b/Resources/Documentation/vanilla/throw~.md
@@ -11,12 +11,13 @@ inlets:
   1st:
   - type: signal
     description: signal to throw to a matching catch~ object
-  - type: set <symbol>
-    description: set throw~ name
 arguments:
 - type: symbol
   description: throw~ symbol name 
   default: empty symbol
+methods:
+  - type: set <symbol>
+    description: set throw~ name
 draft: false
 ---
 Any number of throw~ objects can add into one catch~ object (but two catch~ objects cannot share the same name.

--- a/Resources/Documentation/vanilla/trigger.md
+++ b/Resources/Documentation/vanilla/trigger.md
@@ -9,7 +9,7 @@ see_also:
 - bang
 - unpack
 arguments:
-- description: symbols that define outlet's message type. 'float', 'bang', 'symbol', 'list', 'anything', and 'pointer',  all of which can be abbreviatted
+- description: symbols that define outlet's message type. 'float', 'bang', 'symbol', 'list', 'anything', and 'pointer',  all of which can be abbreviated
   default: f f
   type: list
 inlets:

--- a/Resources/Documentation/vanilla/unpack.md
+++ b/Resources/Documentation/vanilla/unpack.md
@@ -9,7 +9,7 @@ see_also:
 - pack
 - trigger
 arguments:
-- description: symbols that define atom types: 'float',  'symbol',  and 'pointer' (can be abbreviated)
+- description: symbols defining atom types: float/symbol/pointer (f/s/p)
   default: f f
   type: list
 inlets:

--- a/Resources/Documentation/vanilla/vcf~.md
+++ b/Resources/Documentation/vanilla/vcf~.md
@@ -1,6 +1,6 @@
 ---
 title: vcf~
-description: voltage-controlled band/low-pass filter
+description: voltage-controlled band/lowpass filter
 categories:
 - object
 see_also:
@@ -39,4 +39,4 @@ arguments:
   default: 0
 draft: false
 ---
-Vcf~ is a resonant band-pass and low-pass filter that takes either a control or an audio signal to set center frequency, which may thus change continuously in time as in an analog voltage controlled filter (and unlike 'bp~' and 'lop~' that only take control values
+Vcf~ is a resonant bandpass and lowpass filter that takes either a control or an audio signal to set center frequency, which may thus change continuously in time as in an analog voltage controlled filter (and unlike 'bp~' and 'lop~' that only take control values

--- a/Resources/Documentation/vanilla/vcf~.md
+++ b/Resources/Documentation/vanilla/vcf~.md
@@ -29,7 +29,7 @@ inlets:
 outlets:
   1st:
   - type: signal
-    description: real output (bandpasse filtered signal). 
+    description: real output (bandpasse filtered signal)
   2nd:
   - type: signal
     description: imaginary output (bandpasse filtered signal)

--- a/Resources/Documentation/vanilla/vradio.md
+++ b/Resources/Documentation/vanilla/vradio.md
@@ -14,11 +14,11 @@ methods:
 - type: size <float>
   description: sets the GUI size
 - type: orientation <float>
-  description: non zero sets to vertical, zero sets to horizontal
+  description: non-0 sets to vertical, zero sets to horizontal
 - type: number <float>
   description: sets number of cells
 - type: init <float>
-  description: non zero sets to init mode
+  description: non-0 sets to init mode
 - type: label <symbol>
   description: sets label symbol
 - type: label_font <float, float>

--- a/Resources/Documentation/vanilla/vslider.md
+++ b/Resources/Documentation/vanilla/vslider.md
@@ -14,7 +14,7 @@ methods:
 - type: size <float>
   description: sets the GUI size
 - type: orientation <float>
-  description: non zero sets to vertical, zero sets to horizontal
+  description: non-0 sets to vertical, zero sets to horizontal
 - type: range <float, float>
   description: sets minimum and maximum range
 - type: lin
@@ -22,7 +22,7 @@ methods:
 - type: log
   description: sets mode to logarithmic
 - type: init <float>
-  description: non zero sets to init mode
+  description: non-0 sets to init mode
 - type: label <symbol>
   description: sets label symbol
 - type: label_font <float, float>

--- a/Resources/Documentation/vanilla/vu.md
+++ b/Resources/Documentation/vanilla/vu.md
@@ -5,22 +5,22 @@ pdcategory: vanilla, UI
 inlets:
   1st:
   - type: float
-    description: set RMS value in dbFS
+    description: set RMS value in dBFS
   2nd:
   - type: float
-    description: set peak value in dbFS
+    description: set peak value in dBFS
 outlets:
   1st:
   - type: float
-    description: RMS value in dbFS
+    description: RMS value in dBFS
   2st:
   - type: float
-    description: Peak value in dbFS
+    description: Peak value in dBFS
 methods:
 - type: size <float>
   description: sets the GUI size
 - type: scale <float>
-  description: nonzero shows scale (default), zero hides it
+  description: non-0 shows scale (default), zero hides it
 - type: label <symbol>
   description: sets label symbol
 - type: label_font <float, float>

--- a/Resources/Documentation/vanilla/wrap.md
+++ b/Resources/Documentation/vanilla/wrap.md
@@ -12,11 +12,11 @@ see_also:
 inlets:
   1st:
   - type: float
-    description: Input value
+    description: input value
 outlets:
   1st:
   - type: float
-    description: The result of the operation
+    description: the result of the operation
 draft: false
 ---
 The wrap object wraps the input to a value between 0 and 1, including negative numbers (for instance, -0.2 maps to 0.8.)


### PR DESCRIPTION
non-0, bandpass, lowpass, highpass, allpass, bandstop, Hz, in % (in place of "in percentage"), dB, Inf, and NaN across all docs