### PR TITLE
Improved grid snap & adjustable grid size

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -52,6 +52,8 @@ Canvas::Canvas(PluginEditor* parent, pd::Patch& p, Component* parentGraph)
     commandLocked.referTo(pd->commandLocked);
     commandLocked.addListener(this);
 
+    gridEnabled.referTo(SettingsFile::getInstance()->getPropertyAsValue("grid_enabled"));
+    //gridEnabled.addListener(this);
     tabbar = &editor->tabbar;
 
     // Add draggable border for setting graph position
@@ -955,6 +957,12 @@ void Canvas::checkBounds()
 
 void Canvas::valueChanged(Value& v)
 {
+    // Changes to gridEnabled
+    if (v.refersToSameSourceAs(gridEnabled)) {
+    std::cout << "gridEnabled Changed" << std::endl;
+
+    }
+
     // When lock changes
     if (v.refersToSameSourceAs(locked)) {
         bool editMode = !static_cast<bool>(v.getValue());

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -53,7 +53,7 @@ Canvas::Canvas(PluginEditor* parent, pd::Patch& p, Component* parentGraph)
     commandLocked.addListener(this);
 
     gridEnabled.referTo(SettingsFile::getInstance()->getPropertyAsValue("grid_enabled"));
-    //gridEnabled.addListener(this);
+
     tabbar = &editor->tabbar;
 
     // Add draggable border for setting graph position

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -52,9 +52,6 @@ Canvas::Canvas(PluginEditor* parent, pd::Patch& p, Component* parentGraph)
     commandLocked.referTo(pd->commandLocked);
     commandLocked.addListener(this);
 
-    // TODO: use SettingsFileListener
-    gridEnabled.referTo(SettingsFile::getInstance()->getPropertyAsValue("grid_enabled"));
-
     tabbar = &editor->tabbar;
 
     // Add draggable border for setting graph position
@@ -133,8 +130,8 @@ void Canvas::paint(Graphics& g)
 
         g.setColour(findColour(PlugDataColour::canvasDotsColourId));
 
-        for (int x = canvasOrigin.getX() + grid.gridSize; x < clipBounds.getRight(); x += grid.gridSize) {
-            for (int y = canvasOrigin.getY() + grid.gridSize; y < clipBounds.getBottom(); y += grid.gridSize) {
+        for (int x = canvasOrigin.getX() + objectGrid.gridSize; x < clipBounds.getRight(); x += objectGrid.gridSize) {
+            for (int y = canvasOrigin.getY() + objectGrid.gridSize; y < clipBounds.getBottom(); y += objectGrid.gridSize) {
                 g.fillRect(static_cast<float>(x), static_cast<float>(y), 1.0, 1.0);
             }
         }
@@ -1140,7 +1137,7 @@ void Canvas::objectMouseUp(Object* component, MouseEvent const& e)
         // In case we dragged near the iolet and the canvas moved
         auto canvasMoveOffset = canvasDragStartPosition - getPosition();
 
-        distance = grid.handleMouseUp(distance) + canvasMoveOffset;
+        distance = objectGrid.handleMouseUp(distance) + canvasMoveOffset;
 
         // When done dragging objects, update positions to pd
         patch.moveObjects(objects, distance.x, distance.y);
@@ -1212,9 +1209,8 @@ void Canvas::objectMouseDrag(MouseEvent const& e)
     // In case we dragged near the edge and the canvas moved
     auto canvasMoveOffset = canvasDragStartPosition - getPosition();
 
-    if (static_cast<bool>(gridEnabled.getValue()) && componentBeingDragged) {
-        dragDistance = grid.performMove(componentBeingDragged, dragDistance);
-    }
+    dragDistance = objectGrid.performMove(componentBeingDragged, dragDistance);
+
 
     // alt+drag will duplicate selection
     if (!wasDragDuplicated && e.mods.isAltDown()) {

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -1217,7 +1217,9 @@ void Canvas::objectMouseDrag(MouseEvent const& e)
     // In case we dragged near the edge and the canvas moved
     auto canvasMoveOffset = canvasDragStartPosition - getPosition();
 
-    dragDistance = objectGrid.performMove(componentBeingDragged, dragDistance);
+    if (static_cast<bool>(gridEnabled.getValue()) && componentBeingDragged) {
+        dragDistance = objectGrid.performMove(componentBeingDragged, dragDistance);
+    }
 
 
     // alt+drag will duplicate selection

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -129,13 +129,12 @@ void Canvas::paint(Graphics& g)
     }
 
     if (locked == var(false) && !isGraph) {
-        int const objectGridSize = 20;
         Rectangle<int> const clipBounds = g.getClipBounds();
 
         g.setColour(findColour(PlugDataColour::canvasDotsColourId));
 
-        for (int x = canvasOrigin.getX() + objectGridSize; x < clipBounds.getRight(); x += objectGridSize) {
-            for (int y = canvasOrigin.getY() + objectGridSize; y < clipBounds.getBottom(); y += objectGridSize) {
+        for (int x = canvasOrigin.getX() + grid.gridSize; x < clipBounds.getRight(); x += grid.gridSize) {
+            for (int y = canvasOrigin.getY() + grid.gridSize; y < clipBounds.getBottom(); y += grid.gridSize) {
                 g.fillRect(static_cast<float>(x), static_cast<float>(y), 1.0, 1.0);
             }
         }

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -52,6 +52,7 @@ Canvas::Canvas(PluginEditor* parent, pd::Patch& p, Component* parentGraph)
     commandLocked.referTo(pd->commandLocked);
     commandLocked.addListener(this);
 
+    // TODO: use SettingsFileListener
     gridEnabled.referTo(SettingsFile::getInstance()->getPropertyAsValue("grid_enabled"));
 
     tabbar = &editor->tabbar;
@@ -957,12 +958,6 @@ void Canvas::checkBounds()
 
 void Canvas::valueChanged(Value& v)
 {
-    // Changes to gridEnabled
-    if (v.refersToSameSourceAs(gridEnabled)) {
-    std::cout << "gridEnabled Changed" << std::endl;
-
-    }
-
     // When lock changes
     if (v.refersToSameSourceAs(locked)) {
         bool editMode = !static_cast<bool>(v.getValue());

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -123,6 +123,7 @@ public:
     Value locked;
     Value commandLocked;
     Value presentationMode;
+    Value gridEnabled;
 
     bool isGraph = false;
     bool hasParentCanvas = false;

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -123,7 +123,6 @@ public:
     Value locked;
     Value commandLocked;
     Value presentationMode;
-    Value gridEnabled = Value(var(true));
 
     bool isGraph = false;
     bool hasParentCanvas = false;
@@ -134,7 +133,7 @@ public:
     Value hideNameAndArgs = Value(var(false));
     Value xRange, yRange;
 
-    ObjectGrid grid = ObjectGrid(this);
+    ObjectGrid objectGrid = ObjectGrid(this);
 
     Point<int> canvasOrigin = { 0, 0 };
     Point<int> canvasDragStartPosition = { 0, 0 };

--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -665,7 +665,7 @@ void Object::mouseUp(MouseEvent const& e)
         for (auto* obj : cnv->getSelectionOfType<Object>())
             objectsToCheck.add(obj);
 
-        cnv->grid.handleMouseUp(e.getOffsetFromDragStart());
+        cnv->objectGrid.handleMouseUp(e.getOffsetFromDragStart());
 
         cnv->pd->enqueueFunction(
             [objectsToCheck]() mutable {
@@ -721,7 +721,7 @@ void Object::mouseDrag(MouseEvent const& e)
     } else if (validResizeZone && !originalBounds.isEmpty()) {
 
         auto draggedBounds = resizeZone.resizeRectangleBy(originalBounds, e.getOffsetFromDragStart());
-        auto dragDistance = cnv->grid.performResize(this, e.getOffsetFromDragStart(), draggedBounds);
+        auto dragDistance = cnv->objectGrid.performResize(this, e.getOffsetFromDragStart(), draggedBounds);
 
         auto toResize = e.mods.isShiftDown() ? cnv->getSelectionOfType<Object>() : Array<Object*> { this };
 

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -359,14 +359,24 @@ bool ObjectGrid::isAlreadySnapped(bool horizontal, Point<int>& dragOffset)
 
 Point<int> ObjectGrid::handleMouseUp(Point<int> dragOffset)
 {
-    dragOffset = snappedPosition;
-    if (snapped[1]) {
-        //
-        clear(1);
-    }
-    if (snapped[0]) {
-        //dragOffset.y = snappedPosition.y;
-        clear(0);
+    // dragOffset = snappedPosition;
+    if (gridEnabled == 1 && !ModifierKeys::getCurrentModifiers().isShiftDown()) {
+        if (snapped[1]) {
+            dragOffset.x = snappedPosition.x;
+            clear(1);
+        }
+        if (snapped[0]) {
+            dragOffset.y = snappedPosition.y;
+            clear(0);
+        }
+    } else if ((gridEnabled == 2 || gridEnabled == 3) && !ModifierKeys::getCurrentModifiers().isShiftDown()) {
+        dragOffset = snappedPosition;
+        if (snapped[1]) {
+            clear(1);
+        }
+        if (snapped[0]) {
+            clear(0);
+        }
     }
     return dragOffset;
 }

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -185,23 +185,23 @@ Point<int> ObjectGrid::performResize(Object* toDrag, Point<int> dragOffset, Rect
             updateMarker();
         });
 
-        return dragOffset;
+        if (gridEnabled == 1) {
+            return dragOffset;
+        }
     }
 
     // Snap to Grid
     if (gridEnabled == 2 || gridEnabled == 3) { 
-        auto roundedDrag = (dragOffset / 10) * 10;
-        auto objectPos = toDrag->originalBounds.reduced(Object::margin).getPosition();
-        auto offset = ((objectPos / 10) * 10) - objectPos;
-
-        auto totalOffset = roundedDrag + offset;
-
-        snappedPosition = totalOffset;
-
-        snapped[0] = true;
-        snapped[1] = true;
-
-        return totalOffset;
+        Point<int> newPos = toDrag->originalBounds.reduced(Object::margin).getPosition() + dragOffset;
+        if (!isAlreadySnapped(true, dragOffset)) {
+            newPos.setX(roundToInt(newPos.getX() / gridSize + 1) * gridSize);
+            snappedPosition.x = newPos.x - toDrag->originalBounds.reduced(Object::margin).getX() - gridSize;
+        }
+        if (!isAlreadySnapped(false, dragOffset)) {
+            newPos.setY(roundToInt(newPos.getY() / gridSize + 1) * gridSize);
+            snappedPosition.y = newPos.y - toDrag->originalBounds.reduced(Object::margin).getY() - gridSize;
+        }
+        return snappedPosition;
     }
 }
 

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -211,9 +211,7 @@ Point<int> ObjectGrid::performMove(Object* toDrag, Point<int> dragOffset)
         Point<int> newPos =  toDrag->originalBounds.reduced(Object::margin).getPosition() + dragOffset;
         newPos.setX(roundToInt(newPos.getX() / gridSize * gridSize));
         newPos.setY(roundToInt(newPos.getY() / gridSize * gridSize));
-        //toDrag->setPosition(newPos);
-        std::cout << "x " << newPos.x << std::endl;
-        std::cout << "y " << newPos.y << std::endl;
+
         snappedPosition = newPos - toDrag->originalBounds.reduced(Object::margin).getPosition();
         
 

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -140,7 +140,7 @@ Point<int> ObjectGrid::performResize(Object* toDrag, Point<int> dragOffset, Rect
         auto b2 = newResizeBounds.reduced(Object::margin);
         auto ratio = toDrag->constrainer->getFixedAspectRatio();
 
-        if (!isAlreadySnapped(false, dragOffset)) {
+        if (!isAlreadySnapped(false, true, dragOffset)) {
             for (auto* object : snappable) {
                 auto b1 = object->getBounds().reduced(Object::margin);
 
@@ -157,7 +157,7 @@ Point<int> ObjectGrid::performResize(Object* toDrag, Point<int> dragOffset, Rect
             }
         }
 
-        if (!isAlreadySnapped(true, dragOffset)) {
+        if (!isAlreadySnapped(true, true, dragOffset)) {
             for (auto* object : snappable) {
 
                 auto b1 = object->getBounds().reduced(Object::margin);
@@ -187,11 +187,11 @@ Point<int> ObjectGrid::performResize(Object* toDrag, Point<int> dragOffset, Rect
     // Snap to Grid
     if (gridEnabled == 2 || gridEnabled == 3) { 
         Point<int> newPos = toDrag->originalBounds.reduced(Object::margin).getPosition() + dragOffset;
-        if (!isAlreadySnapped(true, dragOffset)) {
+        if (!isAlreadySnapped(true, true, dragOffset)) {
             newPos.setX(roundToInt(newPos.getX() / gridSize + 1) * gridSize);
             snappedPosition.x = newPos.x - toDrag->originalBounds.reduced(Object::margin).getX() - gridSize;
         }
-        if (!isAlreadySnapped(false, dragOffset)) {
+        if (!isAlreadySnapped(false, true, dragOffset)) {
             newPos.setY(roundToInt(newPos.getY() / gridSize + 1) * gridSize);
             snappedPosition.y = newPos.y - toDrag->originalBounds.reduced(Object::margin).getY() - gridSize;
         }
@@ -208,7 +208,7 @@ Point<int> ObjectGrid::performMove(Object* toDrag, Point<int> dragOffset)
         auto snappable = getSnappableObjects(toDrag->cnv);
         auto b2 = (toDrag->originalBounds + dragOffset).reduced(Object::margin);
 
-        if (!isAlreadySnapped(false, dragOffset)) {
+        if (!isAlreadySnapped(false, false, dragOffset)) {
 
             for (auto* object : snappable) {
                 auto b1 = object->getBounds().reduced(Object::margin);
@@ -231,7 +231,7 @@ Point<int> ObjectGrid::performMove(Object* toDrag, Point<int> dragOffset)
             }
         }
 
-        if (!isAlreadySnapped(true, dragOffset)) {
+        if (!isAlreadySnapped(true, false, dragOffset)) {
 
             // Find snap points based on connection alignment
             for (auto* connection : toDrag->getConnections()) {
@@ -272,7 +272,7 @@ Point<int> ObjectGrid::performMove(Object* toDrag, Point<int> dragOffset)
             }
         }
 
-        if (!isAlreadySnapped(true, dragOffset)) {
+        if (!isAlreadySnapped(true, false, dragOffset)) {
             for (auto* object : snappable) {
 
                 auto b1 = object->getBounds().reduced(Object::margin);
@@ -337,21 +337,21 @@ Array<Object*> ObjectGrid::getSnappableObjects(Canvas* cnv)
     return snappable;
 }
 
-bool ObjectGrid::isAlreadySnapped(bool horizontal, Point<int>& dragOffset)
+bool ObjectGrid::isAlreadySnapped(bool horizontal, bool resizing, Point<int>& dragOffset)
 {
     if (horizontal && snapped[1]) {
         if (std::abs(snappedPosition.x - dragOffset.x) > range) {
             clear(true);
             return true;
         }
-        dragOffset = { snappedPosition.x, snappedPosition.y };
+        dragOffset = { snappedPosition.x, resizing ? snappedPosition.y : dragOffset.y };
         return true;
     } else if (!horizontal && snapped[0]) {
         if (std::abs(snappedPosition.y - dragOffset.y) > range) {
             clear(false);
             return true;
         }
-        dragOffset = { snappedPosition.x, snappedPosition.y };
+        dragOffset = { resizing ? dragOffset.x : snappedPosition.x, snappedPosition.y };
         return true;
     }
 

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -201,7 +201,7 @@ Point<int> ObjectGrid::performResize(Object* toDrag, Point<int> dragOffset, Rect
 Point<int> ObjectGrid::performMove(Object* toDrag, Point<int> dragOffset)
 {
 
-    if (gridEnabled == 0) { // Grid is disabled
+    if (gridEnabled == 0 || ModifierKeys::getCurrentModifiers().isShiftDown()) { // Grid is disabled
         return dragOffset;
     }
 

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -11,7 +11,7 @@
 #include "LookAndFeel.h"
 #include "Utility/ObjectBoundsConstrainer.h"
 
-ObjectGrid::ObjectGrid(Canvas* parent)
+ObjectGrid::ObjectGrid(Canvas* parent) : cnv(parent)
 {
     for (auto& line : gridLines) {
         parent->addAndMakeVisible(line);
@@ -19,8 +19,9 @@ ObjectGrid::ObjectGrid(Canvas* parent)
         line.setStrokeThickness(1);
         line.setAlwaysOnTop(true);
     }
-
-    gridEnabled = SettingsFile::getInstance()->getProperty<int>("grid_enabled");
+    //gridEnabled.addListener(cnv);
+    // Initialise grid settings
+   //gridEnabled = SettingsFile::getInstance()->getProperty<int>("grid_enabled");
 }
 
 Point<int> ObjectGrid::applySnap(SnapOrientation direction, Point<int> pos, Component* s, Component* e, bool horizontal)
@@ -114,11 +115,6 @@ void ObjectGrid::clear(bool horizontal)
 
 Point<int> ObjectGrid::performResize(Object* toDrag, Point<int> dragOffset, Rectangle<int> newResizeBounds)
 {
-    // Grid is disabled
-    if (gridEnabled == 0 || ModifierKeys::getCurrentModifiers().isShiftDown()) { 
-        return dragOffset;
-    }
-
     // Snap to Objects
     if (gridEnabled == 1 || gridEnabled == 3) { 
 
@@ -203,15 +199,12 @@ Point<int> ObjectGrid::performResize(Object* toDrag, Point<int> dragOffset, Rect
         }
         return snappedPosition;
     }
+
+    return dragOffset;
 }
 
 Point<int> ObjectGrid::performMove(Object* toDrag, Point<int> dragOffset)
 {
-    // Grid is disabled
-    if (gridEnabled == 0 || ModifierKeys::getCurrentModifiers().isShiftDown()) {
-        return dragOffset;
-    }
-
     // Snap to Objects
     if (gridEnabled == 1 || gridEnabled == 3) {
         auto snappable = getSnappableObjects(toDrag->cnv);
@@ -326,6 +319,8 @@ Point<int> ObjectGrid::performMove(Object* toDrag, Point<int> dragOffset)
         }
         return snappedPosition;
     }
+
+    return dragOffset;
 }
 
 Array<Object*> ObjectGrid::getSnappableObjects(Canvas* cnv)

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -115,7 +115,7 @@ void ObjectGrid::clear(bool horizontal)
 Point<int> ObjectGrid::performResize(Object* toDrag, Point<int> dragOffset, Rectangle<int> newResizeBounds)
 {
     // Grid is disabled
-    if (gridEnabled == 0) { 
+    if (gridEnabled == 0 || ModifierKeys::getCurrentModifiers().isShiftDown()) { 
         return dragOffset;
     }
 

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -352,7 +352,7 @@ bool ObjectGrid::isAlreadySnapped(bool horizontal, bool resizing, Point<int>& dr
             clear(false);
             return true;
         }
-        dragOffset = { resizing ? dragOffset.x : snappedPosition.x, snappedPosition.y };
+        dragOffset = { resizing ? snappedPosition.x : dragOffset.x, snappedPosition.y };
         return true;
     }
 

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -20,6 +20,7 @@ ObjectGrid::ObjectGrid(Canvas* parent)
         line.setAlwaysOnTop(true);
     }
     gridEnabled = SettingsFile::getInstance()->getProperty<int>("grid_enabled");
+    gridSize = SettingsFile::getInstance()->getProperty<int>("grid_size");
 }
 
 Point<int> ObjectGrid::applySnap(SnapOrientation direction, Point<int> pos, Component* s, Component* e, bool horizontal)
@@ -386,5 +387,8 @@ void ObjectGrid::propertyChanged(String name, var value)
 {
     if (name == "grid_enabled") {
         gridEnabled = static_cast<int>(value);
+    }
+    if (name == "grid_size") {
+        gridSize = static_cast<int>(value);
     }
 }

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -19,9 +19,7 @@ ObjectGrid::ObjectGrid(Canvas* parent) : cnv(parent)
         line.setStrokeThickness(1);
         line.setAlwaysOnTop(true);
     }
-    //gridEnabled.addListener(cnv);
-    // Initialise grid settings
-   //gridEnabled = SettingsFile::getInstance()->getProperty<int>("grid_enabled");
+    gridEnabled.referTo(SettingsFile::getInstance()->getPropertyAsValue("grid_enabled"));
 }
 
 Point<int> ObjectGrid::applySnap(SnapOrientation direction, Point<int> pos, Component* s, Component* e, bool horizontal)

--- a/Source/ObjectGrid.cpp
+++ b/Source/ObjectGrid.cpp
@@ -11,7 +11,7 @@
 #include "LookAndFeel.h"
 #include "Utility/ObjectBoundsConstrainer.h"
 
-ObjectGrid::ObjectGrid(Canvas* parent) : cnv(parent)
+ObjectGrid::ObjectGrid(Canvas* parent)
 {
     for (auto& line : gridLines) {
         parent->addAndMakeVisible(line);
@@ -19,7 +19,7 @@ ObjectGrid::ObjectGrid(Canvas* parent) : cnv(parent)
         line.setStrokeThickness(1);
         line.setAlwaysOnTop(true);
     }
-    gridEnabled.referTo(SettingsFile::getInstance()->getPropertyAsValue("grid_enabled"));
+    gridEnabled = SettingsFile::getInstance()->getProperty<int>("grid_enabled");
 }
 
 Point<int> ObjectGrid::applySnap(SnapOrientation direction, Point<int> pos, Component* s, Component* e, bool horizontal)
@@ -307,11 +307,11 @@ Point<int> ObjectGrid::performMove(Object* toDrag, Point<int> dragOffset)
     // Snap to Grid
     if (gridEnabled == 2 || gridEnabled == 3) {
         Point<int> newPos = toDrag->originalBounds.reduced(Object::margin).getPosition() + dragOffset;
-        if (!isAlreadySnapped(true, dragOffset)) {
+        if (!isAlreadySnapped(true, false, dragOffset)) {
             newPos.setX(roundToInt(newPos.getX() / gridSize + 1) * gridSize);
             snappedPosition.x = newPos.x - toDrag->originalBounds.reduced(Object::margin).getX() - gridSize;
         }
-        if (!isAlreadySnapped(false, dragOffset)) {
+        if (!isAlreadySnapped(false, false, dragOffset)) {
             newPos.setY(roundToInt(newPos.getY() / gridSize + 1) * gridSize);
             snappedPosition.y = newPos.y - toDrag->originalBounds.reduced(Object::margin).getY() - gridSize;
         }

--- a/Source/ObjectGrid.h
+++ b/Source/ObjectGrid.h
@@ -14,6 +14,7 @@ class ObjectGrid : public SettingsFileListener {
 
 public:
     ObjectGrid(Canvas* parent);
+    
     // Point<int> handleMouseDrag(Object* toDrag, Point<int> dragOffset, Rectangle<int> viewBounds, Rectangle<int> resizeBounds = Rectangle<int>(0, 0, 0, 0));
     Point<int> handleMouseUp(Point<int> dragOffset);
 
@@ -21,8 +22,8 @@ public:
 
     Point<int> performResize(Object* toDrag, Point<int> dragOffset, Rectangle<int> newResizeBounds);
 
-    //TODO: Can we save gridSize in patch? else save in settings File
-    int gridSize = 20;
+    //TODO: Can we save gridSize in patch instead of Settings File??
+    int gridSize;
 
     static constexpr int range = 5;
     static constexpr int tolerance = 3;

--- a/Source/ObjectGrid.h
+++ b/Source/ObjectGrid.h
@@ -14,7 +14,7 @@ class ObjectGrid : public SettingsFileListener {
 
 public:
     ObjectGrid(Canvas* parent);
-
+    int gridSize = 10;
     // Point<int> handleMouseDrag(Object* toDrag, Point<int> dragOffset, Rectangle<int> viewBounds, Rectangle<int> resizeBounds = Rectangle<int>(0, 0, 0, 0));
     Point<int> handleMouseUp(Point<int> dragOffset);
 

--- a/Source/ObjectGrid.h
+++ b/Source/ObjectGrid.h
@@ -14,7 +14,6 @@ class ObjectGrid : public SettingsFileListener {
 
 public:
     ObjectGrid(Canvas* parent);
-    int gridSize = 10;
     // Point<int> handleMouseDrag(Object* toDrag, Point<int> dragOffset, Rectangle<int> viewBounds, Rectangle<int> resizeBounds = Rectangle<int>(0, 0, 0, 0));
     Point<int> handleMouseUp(Point<int> dragOffset);
 
@@ -22,6 +21,7 @@ public:
 
     Point<int> performResize(Object* toDrag, Point<int> dragOffset, Rectangle<int> newResizeBounds);
 
+    int gridSize = 20;
     static constexpr int range = 5;
     static constexpr int tolerance = 3;
 
@@ -36,7 +36,7 @@ private:
     bool snapped[2] = { false, false };
 
     SnapOrientation orientation[2];
-    Point<int> position;
+    Point<int> snappedPosition;
     Component::SafePointer<Component> start[2];
     Component::SafePointer<Component> end[2];
     DrawablePath gridLines[2];

--- a/Source/ObjectGrid.h
+++ b/Source/ObjectGrid.h
@@ -21,11 +21,11 @@ public:
 
     Point<int> performResize(Object* toDrag, Point<int> dragOffset, Rectangle<int> newResizeBounds);
 
+    //TODO: Can we save gridSize in patch? else save in settings File
     int gridSize = 20;
+
     static constexpr int range = 5;
     static constexpr int tolerance = 3;
-
-    Value gridEnabled;
 
 private:
     enum SnapOrientation {
@@ -57,5 +57,6 @@ private:
 
     void propertyChanged(String name, var value) override;
 
+    Value gridEnabled;
     Canvas* cnv;
 };

--- a/Source/ObjectGrid.h
+++ b/Source/ObjectGrid.h
@@ -58,5 +58,5 @@ private:
     void propertyChanged(String name, var value) override;
 
     Value gridEnabled;
-    Canvas* cnv;
+
 };

--- a/Source/ObjectGrid.h
+++ b/Source/ObjectGrid.h
@@ -25,6 +25,8 @@ public:
     static constexpr int range = 5;
     static constexpr int tolerance = 3;
 
+    Value gridEnabled;
+
 private:
     enum SnapOrientation {
         SnappedLeft,
@@ -41,8 +43,6 @@ private:
     Component::SafePointer<Component> end[2];
     DrawablePath gridLines[2];
 
-    int gridEnabled = 1;
-
     Point<int> applySnap(SnapOrientation orientation, Point<int> position, Component* start, Component* end, bool horizontal);
     void updateMarker();
     void clear(bool horizontal);
@@ -56,4 +56,6 @@ private:
     bool isAlreadySnapped(bool horizontal, Point<int>& dragOffset);
 
     void propertyChanged(String name, var value) override;
+
+    Canvas* cnv;
 };

--- a/Source/ObjectGrid.h
+++ b/Source/ObjectGrid.h
@@ -53,7 +53,7 @@ private:
     Point<int> performAbsoluteSnap(Object* toDrag, Point<int> dragOffset);
 
     Array<Object*> getSnappableObjects(Canvas* cnv);
-    bool isAlreadySnapped(bool horizontal, Point<int>& dragOffset);
+    bool isAlreadySnapped(bool horizontal, bool resizing, Point<int>& dragOffset);
 
     void propertyChanged(String name, var value) override;
 

--- a/Source/Statusbar.cpp
+++ b/Source/Statusbar.cpp
@@ -202,8 +202,6 @@ Statusbar::Statusbar(PluginProcessor* processor)
     locked.addListener(this);
     commandLocked.addListener(this);
 
-    gridEnabled.referTo(SettingsFile::getInstance()->getProperty<Value>("grid_enabled"));
-
     oversampleSelector.setTooltip("Set oversampling");
     oversampleSelector.getProperties().set("FontScale", 0.5f);
     oversampleSelector.setColour(ComboBox::outlineColourId, Colours::transparentBlack);
@@ -261,31 +259,31 @@ Statusbar::Statusbar(PluginProcessor* processor)
 
     gridButton->onClick = [this]() {
         PopupMenu gridSelector;
-        auto settings = SettingsFile::getInstance();
-        gridSelector.addItem("Snap to Grid", true, gridEnabled == 2 || gridEnabled == 3, [this, settings]() {
+        int gridEnabled = SettingsFile::getInstance()->getProperty<int>("grid_enabled");
+        gridSelector.addItem("Snap to Grid", true, gridEnabled == 2 || gridEnabled == 3, [this, gridEnabled]() {
             if (gridEnabled == 0) {
-                gridEnabled.setValue(2);
+                SettingsFile::getInstance()->setProperty("grid_enabled", 2);
             } else if (gridEnabled == 1) {
-                gridEnabled.setValue(3);
+                SettingsFile::getInstance()->setProperty("grid_enabled", 3);
             } else if (gridEnabled == 2) {
-                gridEnabled.setValue(0);
+                SettingsFile::getInstance()->setProperty("grid_enabled", 0);
             } else {
-                gridEnabled.setValue(1);
+                SettingsFile::getInstance()->setProperty("grid_enabled", 1);
             }
         });
-        gridSelector.addItem("Snap to Objects", true, gridEnabled == 1 || gridEnabled == 3, [this, settings]() {
+        gridSelector.addItem("Snap to Objects", true, gridEnabled == 1 || gridEnabled == 3, [this, gridEnabled]() {
             if (gridEnabled == 0) {
-                gridEnabled.setValue(1);
+                SettingsFile::getInstance()->setProperty("grid_enabled", 1);
             } else if (gridEnabled == 1) {
-                gridEnabled.setValue(0);
+                SettingsFile::getInstance()->setProperty("grid_enabled", 0);
             } else if (gridEnabled == 2) {
-                gridEnabled.setValue(3);
+                SettingsFile::getInstance()->setProperty("grid_enabled", 3);
             } else {
-                gridEnabled.setValue(2);
+                SettingsFile::getInstance()->setProperty("grid_enabled", 2);
             }
         }); 
         gridSelector.addSeparator();
-        //gridSelector.addCustomItem(1, std::make_unique<gridSizeSlider>(dynamic_cast<PluginEditor*>(pd->getActiveEditor())->getCurrentCanvas())), nullptr, "";
+       // gridSelector.addCustomItem(1, std::make_unique<gridSizeSlider>(dynamic_cast<PluginEditor*>(pd->getActiveEditor())->getCurrentCanvas())), nullptr, "";
 
         gridSelector.showMenuAsync(PopupMenu::Options().withMinimumWidth(150).withMaximumNumColumns(1).withTargetComponent(gridButton.get()).withParentComponent(pd->getActiveEditor()));
     };
@@ -294,7 +292,7 @@ Statusbar::Statusbar(PluginProcessor* processor)
     addAndMakeVisible(gridButton.get());
 
     // Initialise grid state
-    //propertyChanged("grid_enabled", SettingsFile::getInstance()->getProperty<int>("grid_enabled"));
+    propertyChanged("grid_enabled", SettingsFile::getInstance()->getProperty<int>("grid_enabled"));
 
 
     powerButton->onClick = [this]() { powerButton->getToggleState() ? pd->startDSP() : pd->releaseDSP(); };
@@ -384,7 +382,8 @@ void Statusbar::attachToCanvas(Canvas* cnv)
 
 void Statusbar::propertyChanged(String name, var value)
 {
-/*     if (name == "grid_enabled") {
+    if (name == "grid_enabled") {
+        int gridEnabled = static_cast<int>(value);
         if (gridEnabled == 0) {
             gridButton->setColour(TextButton::textColourOffId, findColour(PlugDataColour::toolbarTextColourId));
             gridButton->setColour(TextButton::textColourOnId, findColour(PlugDataColour::toolbarActiveColourId));
@@ -400,7 +399,7 @@ void Statusbar::propertyChanged(String name, var value)
             // TODO: fix weird colour id usage
             gridButton->setColour(TextButton::textColourOnId, findColour(PlugDataColour::signalColourId).brighter(0.4f));
         }
-    } */
+    }
 }
 
 void Statusbar::valueChanged(Value& v)
@@ -469,8 +468,6 @@ void Statusbar::modifierKeysChanged(ModifierKeys const& modifiers)
     auto* editor = dynamic_cast<PluginEditor*>(pd->getActiveEditor());
 
     commandLocked = modifiers.isCommandDown() && locked.getValue() == var(false);
-
-    //gridDisable = modifiers.isShiftDown() && SettingsFile::getInstance()->getProperty<int>("grid_enabled");
 
     if (auto* cnv = editor->getCurrentCanvas()) {
         if (cnv->didStartDragging || cnv->isDraggingLasso || static_cast<bool>(cnv->presentationMode.getValue())) {

--- a/Source/Statusbar.cpp
+++ b/Source/Statusbar.cpp
@@ -148,7 +148,7 @@ public:
 
         addAndMakeVisible(slider.get());
         slider->setRange(5, 30, 5);
-        slider->setValue(cnv->objectGrid.gridSize);
+        slider->setValue(SettingsFile::getInstance()->getProperty<int>("grid_size"));
         slider->setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
         slider->setColour(Slider::ColourIds::trackColourId, findColour(PlugDataColour::panelBackgroundColourId));
         slider->addListener(this);
@@ -156,7 +156,7 @@ public:
 
     void sliderValueChanged(Slider* slider) override
     {
-        canvas->objectGrid.gridSize = slider->getValue();
+        SettingsFile::getInstance()->setProperty("grid_size", slider->getValue());
         canvas->repaint();
     }
 

--- a/Source/Statusbar.cpp
+++ b/Source/Statusbar.cpp
@@ -253,7 +253,7 @@ Statusbar::Statusbar(PluginProcessor* processor)
     powerButton->getProperties().set("Style", "SmallIcon");
     addAndMakeVisible(powerButton.get());
 
-    gridButton->setTooltip("Enable grid");
+    gridButton->setTooltip("Grid Options");
     gridButton->getProperties().set("Style", "SmallIcon");
 
     gridButton->onClick = [this]() {

--- a/Source/Statusbar.cpp
+++ b/Source/Statusbar.cpp
@@ -290,7 +290,7 @@ Statusbar::Statusbar(PluginProcessor* processor)
 
     
     addAndMakeVisible(gridButton.get());
-    
+
     // Initialise grid state
     propertyChanged("grid_enabled", SettingsFile::getInstance()->getProperty<int>("grid_enabled"));
 
@@ -388,11 +388,14 @@ void Statusbar::propertyChanged(String name, var value)
         if (gridEnabled == 0) {
             gridButton->setColour(TextButton::textColourOffId, findColour(PlugDataColour::toolbarTextColourId));
             gridButton->setColour(TextButton::textColourOnId, findColour(PlugDataColour::toolbarActiveColourId));
-        }
-        if (gridEnabled == 1) {
+        } else if (gridEnabled == 1) {
             gridButton->setColour(TextButton::textColourOffId, findColour(PlugDataColour::gridLineColourId));
             gridButton->setColour(TextButton::textColourOnId, findColour(PlugDataColour::gridLineColourId).brighter(0.4f));
         } else if (gridEnabled == 2) {
+            gridButton->setColour(TextButton::textColourOffId, findColour(PlugDataColour::signalColourId));
+            // TODO: fix weird colour id usage
+            gridButton->setColour(TextButton::textColourOnId, findColour(PlugDataColour::signalColourId).brighter(0.4f));
+        } else if (gridEnabled == 3) {
             gridButton->setColour(TextButton::textColourOffId, findColour(PlugDataColour::signalColourId));
             // TODO: fix weird colour id usage
             gridButton->setColour(TextButton::textColourOnId, findColour(PlugDataColour::signalColourId).brighter(0.4f));

--- a/Source/Statusbar.cpp
+++ b/Source/Statusbar.cpp
@@ -283,6 +283,7 @@ Statusbar::Statusbar(PluginProcessor* processor)
             }
         }); 
         gridSelector.addSeparator();
+        auto attachedCanvas = dynamic_cast<PluginEditor*>(pd->getActiveEditor())->getCurrentCanvas();
         gridSelector.addCustomItem(1, std::make_unique<gridSizeSlider>(attachedCanvas), nullptr, "Grid Size");
 
         gridSelector.showMenuAsync(PopupMenu::Options().withMinimumWidth(150).withMaximumNumColumns(1).withTargetComponent(gridButton.get()).withParentComponent(pd->getActiveEditor()));
@@ -378,7 +379,6 @@ void Statusbar::attachToCanvas(Canvas* cnv)
 {
     locked.referTo(cnv->locked);
     lockButton->getToggleStateValue().referTo(cnv->locked);
-    attachedCanvas = cnv;
 }
 
 void Statusbar::propertyChanged(String name, var value)

--- a/Source/Statusbar.cpp
+++ b/Source/Statusbar.cpp
@@ -288,10 +288,12 @@ Statusbar::Statusbar(PluginProcessor* processor)
         gridSelector.showMenuAsync(PopupMenu::Options().withMinimumWidth(150).withMaximumNumColumns(1).withTargetComponent(gridButton.get()).withParentComponent(pd->getActiveEditor()));
     };
 
+    
+    addAndMakeVisible(gridButton.get());
+    
     // Initialise grid state
     propertyChanged("grid_enabled", SettingsFile::getInstance()->getProperty<int>("grid_enabled"));
 
-    addAndMakeVisible(gridButton.get());
 
     powerButton->onClick = [this]() { powerButton->getToggleState() ? pd->startDSP() : pd->releaseDSP(); };
 

--- a/Source/Statusbar.cpp
+++ b/Source/Statusbar.cpp
@@ -260,21 +260,27 @@ Statusbar::Statusbar(PluginProcessor* processor)
         PopupMenu gridSelector;
         auto settings = static_cast<SettingsFile*>(SettingsFile::getInstance());
         int gridEnabled = settings->getProperty<int>("grid_enabled");
-        gridSelector.addItem("Absolute grid", true, gridEnabled == 2 || gridEnabled == 3, [this, settings, gridEnabled]() {
-            gridButton->setColour(TextButton::textColourOffId, Colours::orange);
-            if (gridEnabled == 1) {
+        gridSelector.addItem("Snap to Grid", true, gridEnabled == 2 || gridEnabled == 3, [this, settings, gridEnabled]() {
+            if (gridEnabled == 0) {
+                settings->setProperty("grid_enabled", 2);
+            } else if (gridEnabled == 1) {
+                settings->setProperty("grid_enabled", 3);
+            } else if (gridEnabled == 2) {
+                settings->setProperty("grid_enabled", 0);
+            } else {
+                settings->setProperty("grid_enabled", 1);
+            }
+        });
+        gridSelector.addItem("Snap to Objects", true, gridEnabled == 1 || gridEnabled == 3, [this, settings, gridEnabled]() {
+            if (gridEnabled == 0) {
+                settings->setProperty("grid_enabled", 1);
+            } else if (gridEnabled == 1) {
+                settings->setProperty("grid_enabled", 0);
+            } else if (gridEnabled == 2) {
                 settings->setProperty("grid_enabled", 3);
             } else {
                 settings->setProperty("grid_enabled", 2);
             }
-        });
-        gridSelector.addItem("Relative grid", true, gridEnabled == 1 || gridEnabled == 3, [this]() {
-            gridButton->setColour(TextButton::textColourOffId, findColour(PlugDataColour::gridLineColourId));
-            SettingsFile::getInstance()->setProperty("grid_enabled", 1);
-        });
-        gridSelector.addItem("No grid", true, gridEnabled == 0, [this]() {
-            gridButton->setColour(TextButton::textColourOffId, findColour(PlugDataColour::toolbarTextColourId));
-            SettingsFile::getInstance()->setProperty("grid_enabled", 0);
         });
         gridSelector.addSeparator();
         gridSelector.addCustomItem(1, std::make_unique<gridSizeSlider>(currentCanvas), nullptr, "");

--- a/Source/Statusbar.cpp
+++ b/Source/Statusbar.cpp
@@ -202,6 +202,8 @@ Statusbar::Statusbar(PluginProcessor* processor)
     locked.addListener(this);
     commandLocked.addListener(this);
 
+    gridEnabled.referTo(SettingsFile::getInstance()->getProperty<Value>("grid_enabled"));
+
     oversampleSelector.setTooltip("Set oversampling");
     oversampleSelector.getProperties().set("FontScale", 0.5f);
     oversampleSelector.setColour(ComboBox::outlineColourId, Colours::transparentBlack);
@@ -259,31 +261,28 @@ Statusbar::Statusbar(PluginProcessor* processor)
 
     gridButton->onClick = [this]() {
         PopupMenu gridSelector;
-        auto settings = static_cast<SettingsFile*>(SettingsFile::getInstance());
-        auto gridEnabled = dynamic_cast<PluginEditor*>(pd->getActiveEditor())->getCurrentCanvas()->objectGrid.gridEnable;
-        gridSelector.addItem("Snap to Grid", true, gridEnabled == 2 || gridEnabled == 3, [this, settings, gridEnabled]() {
+        auto settings = SettingsFile::getInstance();
+        gridSelector.addItem("Snap to Grid", true, gridEnabled == 2 || gridEnabled == 3, [this, settings]() {
             if (gridEnabled == 0) {
-                settings->setProperty("grid_enabled", 2);
+                gridEnabled.setValue(2);
             } else if (gridEnabled == 1) {
-                settings->setProperty("grid_enabled", 3);
+                gridEnabled.setValue(3);
             } else if (gridEnabled == 2) {
-                settings->setProperty("grid_enabled", 0);
+                gridEnabled.setValue(0);
             } else {
-                settings->setProperty("grid_enabled", 1);
+                gridEnabled.setValue(1);
             }
-            propertyChanged("grid_enabled", SettingsFile::getInstance()->getProperty<int>("grid_enabled"));
         });
-        gridSelector.addItem("Snap to Objects", true, gridEnabled == 1 || gridEnabled == 3, [this, settings, gridEnabled]() {
+        gridSelector.addItem("Snap to Objects", true, gridEnabled == 1 || gridEnabled == 3, [this, settings]() {
             if (gridEnabled == 0) {
-                settings->setProperty("grid_enabled", 1);
+                gridEnabled.setValue(1);
             } else if (gridEnabled == 1) {
-                settings->setProperty("grid_enabled", 0);
+                gridEnabled.setValue(0);
             } else if (gridEnabled == 2) {
-                settings->setProperty("grid_enabled", 3);
+                gridEnabled.setValue(3);
             } else {
-                settings->setProperty("grid_enabled", 2);
+                gridEnabled.setValue(2);
             }
-            propertyChanged("grid_enabled", SettingsFile::getInstance()->getProperty<int>("grid_enabled"));
         }); 
         gridSelector.addSeparator();
         //gridSelector.addCustomItem(1, std::make_unique<gridSizeSlider>(dynamic_cast<PluginEditor*>(pd->getActiveEditor())->getCurrentCanvas())), nullptr, "";
@@ -295,7 +294,7 @@ Statusbar::Statusbar(PluginProcessor* processor)
     addAndMakeVisible(gridButton.get());
 
     // Initialise grid state
-    propertyChanged("grid_enabled", SettingsFile::getInstance()->getProperty<int>("grid_enabled"));
+    //propertyChanged("grid_enabled", SettingsFile::getInstance()->getProperty<int>("grid_enabled"));
 
 
     powerButton->onClick = [this]() { powerButton->getToggleState() ? pd->startDSP() : pd->releaseDSP(); };
@@ -385,8 +384,7 @@ void Statusbar::attachToCanvas(Canvas* cnv)
 
 void Statusbar::propertyChanged(String name, var value)
 {
-    if (name == "grid_enabled") {
-        auto gridEnabled = dynamic_cast<PluginEditor*>(pd->getActiveEditor())->getCurrentCanvas()->objectGrid.gridEnable;
+/*     if (name == "grid_enabled") {
         if (gridEnabled == 0) {
             gridButton->setColour(TextButton::textColourOffId, findColour(PlugDataColour::toolbarTextColourId));
             gridButton->setColour(TextButton::textColourOnId, findColour(PlugDataColour::toolbarActiveColourId));
@@ -402,7 +400,7 @@ void Statusbar::propertyChanged(String name, var value)
             // TODO: fix weird colour id usage
             gridButton->setColour(TextButton::textColourOnId, findColour(PlugDataColour::signalColourId).brighter(0.4f));
         }
-    }
+    } */
 }
 
 void Statusbar::valueChanged(Value& v)

--- a/Source/Statusbar.cpp
+++ b/Source/Statusbar.cpp
@@ -135,7 +135,7 @@ public:
     {
 
         // Add text boxes to display the interval values
-        for (int i = 5; i <= 25; i += 5) {
+        for (int i = 5; i <= 30; i += 5) {
             auto label = std::make_unique<Label>();
             Font labelFont = label->getFont();
             labelFont.setHeight(10);
@@ -147,7 +147,7 @@ public:
         }
 
         addAndMakeVisible(slider.get());
-        slider->setRange(5, 25, 5);
+        slider->setRange(5, 30, 5);
         slider->setValue(cnv->objectGrid.gridSize);
         slider->setTextBoxStyle(Slider::NoTextBox, false, 0, 0);
         slider->setColour(Slider::ColourIds::trackColourId, findColour(PlugDataColour::panelBackgroundColourId));
@@ -163,19 +163,20 @@ public:
     void getIdealSize(int& idealWidth, int& idealHeight) override
     {
         idealWidth = 150;
-        idealHeight = 20;
+        idealHeight = 25;
     }
 
     void resized() override
     {
         auto bounds = getLocalBounds();
-        bounds.reduce(10, 0);
-         int x = bounds.getX();
-        int spacing = bounds.getWidth() / 5;
+        bounds.reduce(11, 0);
+        int x = bounds.getX();
+        int spacing = bounds.getWidth() / 6;
         for (auto& textBox : intervalTextBoxes) {
             textBox->setBounds(x, bounds.getY(), spacing, bounds.getHeight() - 10);
             x += spacing;
-        } 
+        }
+        bounds.reduce(-1, 0);
         slider->setBounds(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight() + 10);
     }
 
@@ -256,7 +257,6 @@ Statusbar::Statusbar(PluginProcessor* processor)
 
     gridButton->setTooltip("Grid Options");
     gridButton->getProperties().set("Style", "SmallIcon");
-
     gridButton->onClick = [this]() {
         PopupMenu gridSelector;
         int gridEnabled = SettingsFile::getInstance()->getProperty<int>("grid_enabled");
@@ -283,7 +283,7 @@ Statusbar::Statusbar(PluginProcessor* processor)
             }
         }); 
         gridSelector.addSeparator();
-       // gridSelector.addCustomItem(1, std::make_unique<gridSizeSlider>(dynamic_cast<PluginEditor*>(pd->getActiveEditor())->getCurrentCanvas())), nullptr, "";
+        gridSelector.addCustomItem(1, std::make_unique<gridSizeSlider>(attachedCanvas), nullptr, "Grid Size");
 
         gridSelector.showMenuAsync(PopupMenu::Options().withMinimumWidth(150).withMaximumNumColumns(1).withTargetComponent(gridButton.get()).withParentComponent(pd->getActiveEditor()));
     };
@@ -378,6 +378,7 @@ void Statusbar::attachToCanvas(Canvas* cnv)
 {
     locked.referTo(cnv->locked);
     lockButton->getToggleStateValue().referTo(cnv->locked);
+    attachedCanvas = cnv;
 }
 
 void Statusbar::propertyChanged(String name, var value)

--- a/Source/Statusbar.h
+++ b/Source/Statusbar.h
@@ -92,6 +92,7 @@ public:
     Value locked;
     Value commandLocked; // Temporary lock mode
     Value presentationMode;
+    Value gridEnabled;
 
     static constexpr int statusbarHeight = 30;
 

--- a/Source/Statusbar.h
+++ b/Source/Statusbar.h
@@ -97,5 +97,7 @@ public:
     std::unique_ptr<ButtonParameterAttachment> enableAttachment;
     std::unique_ptr<SliderParameterAttachment> volumeAttachment;
 
+    Canvas* attachedCanvas;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Statusbar)
 };

--- a/Source/Statusbar.h
+++ b/Source/Statusbar.h
@@ -72,7 +72,6 @@ public:
     void timerCallback() override;
 
     void attachToCanvas(Canvas* cnv);
-    Canvas* currentCanvas;
 
     void audioProcessedChanged(bool audioProcessed) override;
 
@@ -92,7 +91,6 @@ public:
     Value locked;
     Value commandLocked; // Temporary lock mode
     Value presentationMode;
-    Value gridEnabled;
 
     static constexpr int statusbarHeight = 30;
 

--- a/Source/Statusbar.h
+++ b/Source/Statusbar.h
@@ -97,7 +97,5 @@ public:
     std::unique_ptr<ButtonParameterAttachment> enableAttachment;
     std::unique_ptr<SliderParameterAttachment> volumeAttachment;
 
-    Canvas* attachedCanvas;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Statusbar)
 };

--- a/Source/Statusbar.h
+++ b/Source/Statusbar.h
@@ -11,7 +11,7 @@ class Canvas;
 class LevelMeter;
 class MidiBlinker;
 class PluginProcessor;
-class CustomSlider;
+class gridSizeSlider;
 
 class StatusbarSource : public Timer {
 

--- a/Source/Statusbar.h
+++ b/Source/Statusbar.h
@@ -11,6 +11,7 @@ class Canvas;
 class LevelMeter;
 class MidiBlinker;
 class PluginProcessor;
+class CustomSlider;
 
 class StatusbarSource : public Timer {
 
@@ -71,6 +72,7 @@ public:
     void timerCallback() override;
 
     void attachToCanvas(Canvas* cnv);
+    Canvas* currentCanvas;
 
     void audioProcessedChanged(bool audioProcessed) override;
 

--- a/Source/Utility/SettingsFile.h
+++ b/Source/Utility/SettingsFile.h
@@ -91,6 +91,7 @@ private:
         { "protected", var(1) },
         { "internal_synth", var(0) },
         { "grid_enabled", var(1) },
+        { "grid_size", var(20) },
         { "zoom", var(1.0f) },
         { "default_font", var("Inter") },
         { "native_window", var(false) },


### PR DESCRIPTION
This is a proposal for some new improved grid features:


- Improved Grid Snap: 
- Objects will snap to the actual grid instead of relative to previous pos
- Objects snap to the right margin 
- Can snap to Objects & Grid at the same time if selected

- Resizable Grid Size:
- New slider in the popup to choose Grid Size (this could be improved aesthetically, but it works)
- Grid Size will be saved in SettingsFile (Can we save it in patch instead?)


I merged your latest grid fixes into this as well