### PR TITLE
highlight currently active splitview

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -11,6 +11,7 @@
 #include "LookAndFeel.h"
 #include "SuggestionComponent.h"
 #include "CanvasViewport.h"
+#include "SplitView.h"
 
 #include "Utility/GraphArea.h"
 #include "Utility/RateReducer.h"
@@ -66,7 +67,7 @@ Canvas::Canvas(PluginEditor* parent, pd::Patch& p, bool ownerOfPatch, Component*
     setWantsKeyboardFocus(true);
 
     if (!isGraph) {
-        auto* canvasViewport = new CanvasViewport;
+        auto* canvasViewport = new CanvasViewport(editor, this);
         
         canvasViewport->setViewedComponent(this, false);
         

--- a/Source/CanvasViewport.h
+++ b/Source/CanvasViewport.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Utility/GlobalMouseListener.h"
+#include "LookAndFeel.h"
 
 // Special viewport that shows scrollbars on top of content instead of next to it
 class CanvasViewport : public Viewport
@@ -188,7 +189,9 @@ class CanvasViewport : public Viewport
     };
 
 public:
-    CanvasViewport()
+    CanvasViewport(PluginEditor* parent, Canvas* cnv)
+        : editor(parent)
+        , cnv(cnv)
     {
         recreateScrollbars();
         
@@ -202,6 +205,17 @@ public:
         
         vbar->repaint();
         hbar->repaint();
+    }
+
+    void paintOverChildren(Graphics& g) override
+    {
+        if (editor->splitView.isSplitEnabled()  && editor->splitView.hasFocus(cnv)) {
+            auto thickness = getScrollBarThickness();
+            auto contentArea = getLocalBounds().withTrimmedRight(thickness).withTrimmedBottom(thickness);
+
+            g.setColour(findColour(PlugDataColour::dataColourId));
+            g.drawRect(contentArea.reduced(1), 1.0f);
+        }
     }
     
     void enableMousePanning(bool enablePanning)
@@ -253,7 +267,8 @@ public:
     
     std::function<void()> onScroll = [](){};
 private:
-    
+    PluginEditor* editor;
+    Canvas* cnv;
     MousePanner panner = MousePanner(this);
     FadingScrollbar* vbar = nullptr;
     FadingScrollbar* hbar = nullptr;

--- a/Source/SplitView.h
+++ b/Source/SplitView.h
@@ -6,33 +6,33 @@ class PluginEditor;
 class Canvas;
 class SplitViewResizer;
 class SplitView : public Component {
-    
 public:
     SplitView(PluginEditor* parent);
 
     TabComponent* getActiveTabbar();
     TabComponent* getLeftTabbar();
     TabComponent* getRightTabbar();
-    
+
     void setSplitEnabled(bool splitEnabled);
-    
+    bool isSplitEnabled();
+
     void splitCanvasView(Canvas* cnv, bool splitviewFocus);
-    
+
     void setFocus(Canvas* cnv);
-    
+    bool hasFocus(Canvas* cnv);
+
     void closeEmptySplits();
 
 private:
-    
     void resized() override;
-    
+
     int splitViewWidth = 0;
     bool splitView = false;
     int activeTabIndex = 0;
     bool splitFocusIndex = 0;
     TabComponent splits[2];
-    
+
     PluginEditor* editor;
-    
+
     std::unique_ptr<Component> splitViewResizer;
 };


### PR DESCRIPTION
Address highlight currently active splitview of: #581 

TODO: 
* Switch splitview when any object is selected, not only canvas
* Switch splitview when splitview current tab is selected
* keyboard shortcut for swapping splitview? `shift + right / left arrow`?

![split-view-selected](https://user-images.githubusercontent.com/12004932/221118127-40801d69-0ff6-4368-8497-65eaa7cff720.gif)