### PR TITLE
use UpDownLeftRightResizeCursor instead of hand for GOP moving

### DIFF
--- a/Source/Utility/GraphArea.h
+++ b/Source/Utility/GraphArea.h
@@ -17,7 +17,7 @@ public:
     {
         addAndMakeVisible(resizer);
         updateBounds();
-        setMouseCursor(MouseCursor::DraggingHandCursor);
+        setMouseCursor(MouseCursor::UpDownLeftRightResizeCursor);
     }
 
     void paint(Graphics& g) override


### PR DESCRIPTION
Best not to confuse the canvas drag cursor with moving GOP

![updownleftright](https://user-images.githubusercontent.com/12004932/221362117-4b6ec15b-1f67-4b9a-b577-22ec96c96df4.gif)
