### PR TITLE
click and close messages for text define object ; GOP refreshed when dynamically changed

### DIFF
--- a/Source/Objects/GraphOnParent.h
+++ b/Source/Objects/GraphOnParent.h
@@ -70,6 +70,14 @@ public:
             }
             break;
         }
+        case hash("donecanvasdialog"): {
+            if (atoms.size() >= 11) {
+
+            updateCanvas();
+        	updateDrawables();
+            }
+            break;
+        }
         default:
             break;
         }

--- a/Source/Objects/TextDefineObject.h
+++ b/Source/Objects/TextDefineObject.h
@@ -123,6 +123,20 @@ public:
         });
     }
 
+   void receiveObjectMessage(String const& symbol, std::vector<pd::Atom>& atoms) override
+    {
+        switch (hash(symbol)) {
+        case hash("click"): {
+            MessageManager::callAsync([this]() {
+            openTextEditor();});
+            }
+        case hash("close"): {
+            textEditor.reset(nullptr);
+            }
+        }
+    }
+
+
     String getText() override
     {
         auto& textbuf = static_cast<t_fake_text_define*>(ptr)->x_textbuf;


### PR DESCRIPTION
As in pd Vanilla, clik and close message show / hide the [text define] editor window .
By overriding the `receiveObjectMessage ` function in Source/Objects/TextDefineObject.h
![image](https://user-images.githubusercontent.com/1431894/221664205-b92cda7e-119e-49a9-b613-96c820efcc8d.png)
