### PR TITLE
send slider value on mousedown, even if slider is in Steady On Click …

### DIFF
--- a/Source/Objects/SliderObject.h
+++ b/Source/Objects/SliderObject.h
@@ -96,6 +96,8 @@ public:
 
         slider.onDragStart = [this]() {
             startEdition();
+            const float val = slider.getValue();
+            setValue(val);
         };
 
         slider.onValueChange = [this]() {
@@ -202,7 +204,7 @@ public:
             break;
         }
         }
-        
+
         // Update the colours of the actual slider
         if(hash(symbol) == hash("color"))
         {


### PR DESCRIPTION
…mode
In Pd vanila, if you click to a slider without moving the mouse, it sends its value,whatever the mode (jump on click / steady on click). In Plugdata and steadyonclick mode, you have to drag the mouse to init sending values.

Some projects (for ex. audiolab)  use slider as a flat button on whitch you can click without dragging in order to get a popup menu.
This PR  is proposed for having the same behaviour between puredata and plugdata.

P.S. My new text editor (atom) doesn't change CRLF marks :-)