### PR TITLE
cyclone comment fix

### DIFF
--- a/Source/Objects/CycloneCommentObject.h
+++ b/Source/Objects/CycloneCommentObject.h
@@ -85,8 +85,8 @@ public:
     {
         auto* comment = static_cast<t_fake_comment*>(ptr);
 
-        int width = getBestTextWidth(getText());
-        int height = comment->x_fontsize + 6;
+        int width = getBestTextWidth(getText()) * 8;
+        int height = comment->x_fontsize + 18;
 
         width = std::max(width, 25);
 
@@ -132,8 +132,8 @@ public:
         int fontsize = comment->x_fontsize;
         pd->unlockAudioThread();
 
-        int width = getBestTextWidth(getText());
-        int height = fontsize + 6;
+        int width = getBestTextWidth(getText()) * 8;
+        int height = fontsize + 18;
 
         object->setObjectBounds({ comment->x_obj.te_xpix, comment->x_obj.te_ypix, width, height });
     }


### PR DESCRIPTION
fixes cyclone help files not displaying their titles/descriptions

i just eyeballed it, but it looks fine

before: 
<img width="644" alt="image" src="https://user-images.githubusercontent.com/86204514/222896379-4ece62bc-c902-46cb-b94d-7dd5d3e64ad7.png">
after:
![Screenshot_2023-03-04_12-58-25](https://user-images.githubusercontent.com/86204514/222896395-0876bb38-726a-493c-acfe-1e7f358e32a2.png)

