### PR TITLE
use rounded rectangle instead of Path to fix progressbar glitch

### DIFF
--- a/Source/Heavy/Toolchain.h
+++ b/Source/Heavy/Toolchain.h
@@ -4,6 +4,9 @@
  // WARRANTIES, see the file, "LICENSE.txt," in this distribution.
  */
 
+#include <JuceHeader.h>
+#include "../Constants.h"
+
 struct Toolchain {
 #if JUCE_WINDOWS
     inline static File dir = File::getSpecialLocation(File::SpecialLocationType::userApplicationDataDirectory).getChildFile("plugdata").getChildFile("Toolchain").getChildFile("usr");
@@ -166,32 +169,32 @@ struct ToolchainInstaller : public Component
     {
         auto colour = findColour(PlugDataColour::panelTextColourId);
         if (needsUpdate) {
-            Fonts::drawStyledText(g, "Toolchain needs to be updated", 0, getHeight() / 2 - 150, getWidth(), 40, colour, Bold, 32, Justification::centred);
+            Fonts::drawStyledText(g, "Toolchain needs to be updated", 0, getHeight() / 2 - 150, getWidth(), 40, colour, Bold, 32, Justification::horizontallyCentred);
         } else {
-            Fonts::drawStyledText(g, "Toolchain not found", 0, getHeight() / 2 - 150, getWidth(), 40, colour, Bold, 32, Justification::centred);
+            Fonts::drawStyledText(g, "Toolchain not found", 0, getHeight() / 2 - 150, getWidth(), 40, colour, Bold, 32, Justification::horizontallyCentred);
         }
 
         if (needsUpdate) {
-            Fonts::drawStyledText(g, "Update the toolchain to get started", 0, getHeight() / 2 - 120, getWidth(), 40, colour, Thin, 23, Justification::centred);
+            Fonts::drawStyledText(g, "Update the toolchain to get started", 0, getHeight() / 2 - 120, getWidth(), 40, colour, Thin, 23, Justification::horizontallyCentred);
         } else {
-            Fonts::drawStyledText(g, "Install the toolchain to get started", 0, getHeight() / 2 - 120, getWidth(), 40, colour, Thin, 23, Justification::centred);
+            Fonts::drawStyledText(g, "Install the toolchain to get started", 0, getHeight() / 2 - 120, getWidth(), 40, colour, Thin, 23, Justification::horizontallyCentred);
         }
 
         if (installProgress != 0.0f) {
-            float width = getWidth() - 90.0f;
-            float right = jmap(installProgress, 90.f, width);
+            float width = getWidth() - 180.0f;
+            float progress = jmap(installProgress, 0.0f, width - 3.0f);
 
-            Path downloadPath;
-            downloadPath.addLineSegment({ 90, 300, right, 300 }, 1.0f);
+            float downloadBarBgHeight = 11.0f;
+            float downloadBarHeight = downloadBarBgHeight - 3.0f;
 
-            Path fullPath;
-            fullPath.addLineSegment({ 90, 300, width, 300 }, 1.0f);
+            auto downloadBarBg = Rectangle<float>(90.0f, 300.0f - (downloadBarBgHeight * 0.5), width, downloadBarBgHeight);
+            auto downloadBar = Rectangle<float>(91.5f, 300.0f - (downloadBarHeight * 0.5), progress, downloadBarHeight);
 
             g.setColour(findColour(PlugDataColour::panelTextColourId));
-            g.strokePath(fullPath, PathStrokeType(11.0f, PathStrokeType::JointStyle::curved, PathStrokeType::EndCapStyle::rounded));
+            g.fillRoundedRectangle(downloadBarBg, Corners::defaultCornerRadius);
 
             g.setColour(findColour(PlugDataColour::panelActiveBackgroundColourId));
-            g.strokePath(downloadPath, PathStrokeType(8.0f, PathStrokeType::JointStyle::curved, PathStrokeType::EndCapStyle::rounded));
+            g.fillRoundedRectangle(downloadBar, Corners::smallCornerRadius);
         }
 
         if (errorMessage.isNotEmpty()) {
@@ -205,7 +208,7 @@ struct ToolchainInstaller : public Component
 
     void resized() override
     {
-        installButton.setBounds(getLocalBounds().withSizeKeepingCentre(450, 50).translated(15, -30));
+        installButton.setBounds(getLocalBounds().withSizeKeepingCentre(450, 50).translated(0, -30));
     }
 
     void run() override


### PR DESCRIPTION
Existing progress bar has glitch when Path is too small to render rounded corner, change to using rounded rectangle instead.
Glitch:
![Screenshot from 2023-03-11 16-50-36](https://user-images.githubusercontent.com/12004932/224468699-7ed66203-1934-415c-86ab-0b0a56347772.png)

Fix:
![Screenshot from 2023-03-11 16-42-14](https://user-images.githubusercontent.com/12004932/224468525-15a9a08e-bd18-42cf-86dc-a27904512a45.png)
