### PR TITLE
add macOS style window buttons & setting for left / right position

### DIFF
--- a/Source/Dialogs/AdvancedSettingsPanel.h
+++ b/Source/Dialogs/AdvancedSettingsPanel.h
@@ -3,23 +3,32 @@
  // For information on usage and redistribution, and for a DISCLAIMER OF ALL
  // WARRANTIES, see the file, "LICENSE.txt," in this distribution.
  */
+#include "LookAndFeel.h"
 
 #pragma once
 
-class AdvancedSettingsPanel : public Component {
+class AdvancedSettingsPanel : public Component, public Value::Listener {
 
 public:
     AdvancedSettingsPanel()
     {
         auto* settingsFile = SettingsFile::getInstance();
         nativeTitlebar.referTo(settingsFile->getPropertyAsValue("native_window"));
+        leftWindowButtons.referTo(settingsFile->getPropertyAsValue("left_window_buttons"));
+        macOS_Buttons.referTo(settingsFile->getPropertyAsValue("macos_buttons"));
         reloadPatch.referTo(settingsFile->getPropertyAsValue("reload_last_state"));
 
-        useNativeTitlebar.reset(new PropertiesPanel::BoolComponent("Use system titlebar", nativeTitlebar, { "No", "Yes" }));
+        leftWindowButtons.addListener(this);
+        macOS_Buttons.addListener(this);
 
+        useNativeTitlebar.reset(new PropertiesPanel::BoolComponent("Use system titlebar", nativeTitlebar, { "No", "Yes" }));
+        useLeftWindowButtons.reset(new PropertiesPanel::BoolComponent("Place window buttons left", leftWindowButtons, { "No", "Yes" }));
+        use_macOS_Buttons.reset(new PropertiesPanel::BoolComponent("Use macOS style window buttons", macOS_Buttons, { "No", "Yes" }));
         reloadLastOpenedPatch.reset(new PropertiesPanel::BoolComponent("Reload last opened patch on startup", reloadPatch, { "No", "Yes" }));
 
         addAndMakeVisible(*useNativeTitlebar);
+        addAndMakeVisible(*useLeftWindowButtons);
+        addAndMakeVisible(*use_macOS_Buttons);
         addAndMakeVisible(*reloadLastOpenedPatch);
     }
 
@@ -27,14 +36,34 @@ public:
     {
         auto bounds = getLocalBounds();
         useNativeTitlebar->setBounds(bounds.removeFromTop(23));
+        useLeftWindowButtons->setBounds(bounds.removeFromTop(23));
+        use_macOS_Buttons->setBounds(bounds.removeFromTop(23));
         reloadLastOpenedPatch->setBounds(bounds.removeFromTop(23));
+    }
+
+    void valueChanged(Value& v) override
+    {
+        if (v.refersToSameSourceAs(leftWindowButtons) || v.refersToSameSourceAs(macOS_Buttons)) {
+            auto window = Desktop::getInstance().getComponent(0);
+            // TODO: BUG: for some reason this doesn't change the lnf of the current settings window
+            window->sendLookAndFeelChange();
+
+            // TODO: replace this horrible hack
+            Desktop::getInstance().setGlobalScaleFactor(Desktop::getInstance().getGlobalScaleFactor() - 0.01f);
+            Desktop::getInstance().setGlobalScaleFactor(Desktop::getInstance().getGlobalScaleFactor() + 0.01f);
+        }
     }
 
     ValueTree settingsTree;
 
     Value nativeTitlebar;
+    Value leftWindowButtons;
+    Value macOS_Buttons;
     Value reloadPatch;
 
+
     std::unique_ptr<PropertiesPanel::BoolComponent> useNativeTitlebar;
+    std::unique_ptr<PropertiesPanel::BoolComponent> useLeftWindowButtons;
+    std::unique_ptr<PropertiesPanel::BoolComponent> use_macOS_Buttons;
     std::unique_ptr<PropertiesPanel::BoolComponent> reloadLastOpenedPatch;
 };

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -302,14 +302,16 @@ void PluginEditor::resized()
     sidebar->setBounds(getWidth() - sidebar->getWidth(), toolbarHeight, sidebar->getWidth(), getHeight() - toolbarHeight);
     statusbar->setBounds(0, getHeight() - statusbar->getHeight(), getWidth() - sidebar->getWidth(), statusbar->getHeight());
 
-    mainMenuButton.setBounds(20, 0, toolbarHeight, toolbarHeight);
-    undoButton.setBounds(90, 0, toolbarHeight, toolbarHeight);
-    redoButton.setBounds(160, 0, toolbarHeight, toolbarHeight);
-    addObjectMenuButton.setBounds(230, 0, toolbarHeight, toolbarHeight);
-
+    auto useLeftButtons = SettingsFile::getInstance()->getProperty<bool>("left_window_buttons");
     auto useNonNativeTitlebar = ProjectInfo::isStandalone && !SettingsFile::getInstance()->getProperty<bool>("native_window");
-    
-    auto windowControlsOffset = useNonNativeTitlebar ? 170.0f : 70.0f;
+    auto offset = useLeftButtons && useNonNativeTitlebar ? 90 : 0;
+
+    mainMenuButton.setBounds(20 + offset, 0, toolbarHeight, toolbarHeight);
+    undoButton.setBounds(90 + offset, 0, toolbarHeight, toolbarHeight);
+    redoButton.setBounds(160 + offset, 0, toolbarHeight, toolbarHeight);
+    addObjectMenuButton.setBounds(230 + offset, 0, toolbarHeight, toolbarHeight);
+
+    auto windowControlsOffset = (useNonNativeTitlebar && !useLeftButtons) ? 170.0f : 70.0f;
 
     if(!ProjectInfo::isStandalone) {
         int const resizerSize = 18;

--- a/Source/Utility/SettingsFile.h
+++ b/Source/Utility/SettingsFile.h
@@ -96,6 +96,8 @@ private:
         { "split_zoom", var(1.0f) },
         { "default_font", var("Inter") },
         { "native_window", var(false) },
+        { "left_window_buttons", var(false) },
+        { "macos_buttons", var(false) },
         { "reload_last_state", var(false) },
         { "autoconnect", var(true) }
     };


### PR DESCRIPTION
![Screenshot from 2023-03-12 16-36-44](https://user-images.githubusercontent.com/12004932/224532033-07a6fd07-e3ba-4cda-b369-5b4c662163d5.png)

Known issues:
* settings window doesn't change it's look (close button look) when changing setting
* advanced settings are only available in standalone
* when making plugdata fullscreen, the offset in left button mode is not subtracted (I can't get `isFullscreen()` to output true when fullscreen)
* when changing style & position setting, fullscreen mode is effected (window becomes smaller) 
* Default is not platform dependent at this point