### PR TITLE
Set fallback buildtype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ if(RUN_CLANG_TIDY)
   set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 endif()
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING 
+    "Default build type: Release" FORCE)
+endif()
+
 set(HARDENED_RUNTIME_ENABLED YES)
 set(HARDENED_RUNTIME_OPTIONS "com.apple.security.device.audio-input")
 


### PR DESCRIPTION
When compiling local without specifying a buildtype, depending on the used generator, 
it may result in "non optimized, without debug symbols", best of both worlds so to speak.
This sets it to Release as a fallback type.