### PR TITLE
fix [note]'s color method

### DIFF
--- a/Source/Objects/NoteObject.h
+++ b/Source/Objects/NoteObject.h
@@ -429,7 +429,7 @@ public:
             break;
         }
         case hash("color"): {
-            primaryColour = Colour(note->x_color[0], note->x_color[1], note->x_color[2]).toString();
+            primaryColour = Colour(note->x_red, note->x_green, note->x_blue).toString();
             break;
         }
         case hash("bgcolor"): {


### PR DESCRIPTION
note: i don't know what the `char x_color[8];` is for, since it's not used anywhere now!

before: (skip to half the video, i was testing something else)

https://user-images.githubusercontent.com/86204514/227552645-66cee4e8-726d-4a73-9746-788deb4152ac.mp4

after:

https://user-images.githubusercontent.com/86204514/227552809-3574fd10-0cb1-46c0-bfe2-a34b02824420.mp4

