### PR TITLE
WIP: re-add stlink changes

### DIFF
--- a/Source/Heavy/DaisyExporter.h
+++ b/Source/Heavy/DaisyExporter.h
@@ -8,12 +8,14 @@ class DaisyExporter : public ExporterBase {
 public:
     Value targetBoardValue = Value(var(1));
     Value exportTypeValue = Value(var(3));
+    Value stlinkValue = Value(var(1));
     Value romOptimisationType = Value(var(2));
     Value ramOptimisationType = Value(var(2));
 
     File customBoardDefinition;
 
     TextButton flashButton = TextButton("Flash");
+    Component* stlinkUse;
     Component* ramOptimisation;
     Component* romOptimisation;
 
@@ -23,6 +25,7 @@ public:
         addAndMakeVisible(properties.add(new PropertiesPanel::ComboComponent("Target board", targetBoardValue, { "Seed", "Pod", "Petal", "Patch", "Patch Init", "Field", "Simple", "Custom JSON..." })));
 
         addAndMakeVisible(properties.add(new PropertiesPanel::ComboComponent("Export type", exportTypeValue, { "Source code", "Binary", "Flash" })));
+        addAndMakeVisible(stlinkUse = properties.add(new PropertiesPanel::BoolComponent("Use stlink", stlinkValue, { "No", "Yes" })));
 
         addAndMakeVisible(romOptimisation = properties.add(new PropertiesPanel::ComboComponent("ROM Optimisation", romOptimisationType, { "Optimise for size", "Optimise for speed" })));
         addAndMakeVisible(ramOptimisation = properties.add(new PropertiesPanel::ComboComponent("RAM Optimisation", ramOptimisationType, { "Optimise for size", "Optimise for speed" })));
@@ -56,6 +59,7 @@ public:
         exportButton.setVisible(!flash);
         flashButton.setVisible(flash);
 
+        stlinkUse->setVisible(flash);
         ramOptimisation->setVisible(flash);
         romOptimisation->setVisible(flash);
 
@@ -86,6 +90,7 @@ public:
         auto target = static_cast<int>(targetBoardValue.getValue()) - 1;
         bool compile = static_cast<int>(exportTypeValue.getValue()) - 1;
         bool flash = static_cast<int>(exportTypeValue.getValue()) == 3;
+        bool stlink = static_cast<int>(stlinkValue.getValue());
 
         StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o" + outdir };
 
@@ -163,6 +168,7 @@ public:
             bool bootloader = setMakefileVariables(sourceDir.getChildFile("Makefile"));
 
             auto gccPath = bin.getFullPathName();
+            auto ocdDir = Toolchain::dir.getChildFile("etc").getFullPathName();
 
 #if JUCE_WINDOWS
             auto buildScript = make.getFullPathName().replaceCharacter('\\', '/')
@@ -235,10 +241,17 @@ public:
                     + " PROJECT_NAME=" + name;
 #else
                 String flashScript = "export PATH=\"" + bin.getFullPathName() + ":$PATH\"\n"
-                    + "cd " + sourceDir.getFullPathName() + "\n"
-                    + make.getFullPathName() + " program-dfu"
-                    + " GCC_PATH=" + gccPath
-                    + " PROJECT_NAME=" + name;
+                    + "cd " + sourceDir.getFullPathName() + "\n";
+                if (stlink) {
+                    flashScript += make.getFullPathName() + " program"
+                                 + " OCD_DIR=" + ocdDir
+                                 + " PGM_DEVICE=stlink.cfg";
+                } else {
+                    flashScript += make.getFullPathName() + " program-dfu";
+                }
+
+                flashScript += " GCC_PATH=" + gccPath
+                             + " PROJECT_NAME=" + name;
 #endif
 
                 Toolchain::startShellScript(flashScript, this);


### PR DESCRIPTION
**DO NOT MERGE YET**

This hopefully resolves https://github.com/plugdata-team/plugdata/issues/379 and requires openocd and stlink.cfg in https://github.com/plugdata-team/plugdata-heavy-toolchain

Still needs some tweaks to `JUCE_WINDOWS` section ;)

It would be best to make `No` the default option, but I don't know how to do this for `PropertiesPanel::BoolComponent`.

Also doesn't work for RAM optimized builds: `Cannot program via openocd with an app type of "BOOT_SRAM".`
And ROM optimized builds look the same as plain, but don't actually flash? weird.