### PR TITLE
Hide titlebar buttons on fullscreen MacOS

### DIFF
--- a/Source/LookAndFeel.h
+++ b/Source/LookAndFeel.h
@@ -556,10 +556,13 @@ struct PlugDataLook : public LookAndFeel_V4 {
 
         auto areButtonsLeft = SettingsFile::getInstance()->getProperty<bool>("macos_buttons");
 
+#if JUCE_MAC
+        // Hide title bar buttons when fullscreen on MacOS
         bool visible = !window.isFullScreen();
         minimiseButton->setVisible(visible);
         maximiseButton->setVisible(visible);
         closeButton->setVisible(visible);
+#endif
 
             // heuristic to offset the buttons when positioned left, as we are drawing larger to provide a shadow
             // we check if the system is drawing with a dropshadow- hence semi transparent will be true

--- a/Source/LookAndFeel.h
+++ b/Source/LookAndFeel.h
@@ -551,10 +551,18 @@ struct PlugDataLook : public LookAndFeel_V4 {
         Button* closeButton,
         bool positionTitleBarButtonsOnLeft) override
     {
+        if (window.isUsingNativeTitleBar())
+            return;
+
         auto areButtonsLeft = SettingsFile::getInstance()->getProperty<bool>("macos_buttons");
 
-        // heuristic to offset the buttons when positioned left, as we are drawing larger to provide a shadow
-        // we check if the system is drawing with a dropshadow- hence semi transparent will be true
+        bool visible = !window.isFullScreen();
+        minimiseButton->setVisible(visible);
+        maximiseButton->setVisible(visible);
+        closeButton->setVisible(visible);
+
+            // heuristic to offset the buttons when positioned left, as we are drawing larger to provide a shadow
+            // we check if the system is drawing with a dropshadow- hence semi transparent will be true
 #if JUCE_LINUX
         auto leftOffset = titleBarX;
         if (maximiseButton != nullptr && areButtonsLeft && Desktop::canUseSemiTransparentWindows()) {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -396,6 +396,10 @@ void PluginEditor::resized()
     auto useLeftButtons = SettingsFile::getInstance()->getProperty<bool>("macos_buttons");
     auto useNonNativeTitlebar = ProjectInfo::isStandalone && !SettingsFile::getInstance()->getProperty<bool>("native_window");
     auto offset = useLeftButtons && useNonNativeTitlebar ? 70 : 0;
+#if JUCE_MAC
+    if (auto standalone = ProjectInfo::isStandalone ? dynamic_cast<DocumentWindow*>(getTopLevelComponent()) : nullptr)
+        offset = standalone->isFullScreen() ? 0 : offset;
+#endif
 
     mainMenuButton.setBounds(20 + offset, 0, toolbarHeight, toolbarHeight);
     undoButton.setBounds(80 + offset, 0, toolbarHeight, toolbarHeight);


### PR DESCRIPTION
MacOS handles fullscreen windows natively.
Don't know how it works on Linux/Windows