### PR TITLE
Fix settings shortcut crash

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1181,7 +1181,13 @@ void PluginEditor::getCommandInfo(const CommandID commandID, ApplicationCommandI
     case CommandIDs::ShowSettings: {
         result.setInfo("Open Settings", "Open settings panel", "Edit", 0);
         result.addDefaultKeypress(44, ModifierKeys::commandModifier); // Cmd + , to open settings
-        result.setActive(true);
+        if (!getCurrentCanvas()) {
+            // Disable the key command if there is no canvas
+            // to prevent app from crashing
+            result.setActive(false);
+        } else {
+            result.setActive(true);
+        }
         break;
     }
     case CommandIDs::ShowReference: {


### PR DESCRIPTION
I think this is a JUCE bug.. So i disabled the shortcut if no canvas is present