### PR TITLE
Object owns selection

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -874,6 +874,9 @@ void Canvas::duplicateSelection()
 
     patch.startUndoSequence("Duplicate");
 
+    // clear all previous selections from pd
+    patch.deselectAll();
+
     for (auto* object : selection) {
         // Check if object exists in pd and is not attached to mouse
         if (!object->gui || object->attachedToMouse)

--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -799,14 +799,7 @@ bool Canvas::keyPressed(KeyPress const& key)
 
 void Canvas::deselectAll()
 {
-    auto selection = selectedComponents;
-
     selectedComponents.deselectAll();
-
-    // Deselect objects
-    for (auto c : selection)
-        if (!c.wasObjectDeleted())
-            c->repaint();
 
     editor->sidebar->hideParameters();
 }
@@ -878,6 +871,7 @@ void Canvas::duplicateSelection()
 {
     Array<Connection*> conInlets, conOutlets;
     auto selection = getSelectionOfType<Object>();
+
     patch.startUndoSequence("Duplicate");
 
     for (auto* object : selection) {
@@ -1333,12 +1327,10 @@ void Canvas::setSelected(Component* component, bool shouldNowBeSelected, bool up
 
     if (!isAlreadySelected && shouldNowBeSelected) {
         selectedComponents.addToSelection(component);
-        component->repaint();
     }
 
     if (isAlreadySelected && !shouldNowBeSelected) {
         removeSelectedComponent(component);
-        component->repaint();
     }
 
     if (updateCommandStatus && isAlreadySelected != shouldNowBeSelected) {
@@ -1384,7 +1376,6 @@ void Canvas::findLassoItemsInArea(Array<WeakReference<Component>>& itemsFound, R
         auto selB = object->getSelectableBounds() + canvasOrigin;
         if (area.intersects(object->getSelectableBounds())) {
             itemsFound.add(object);
-            setSelected(object, true, false);
         } else if (!ModifierKeys::getCurrentModifiers().isAnyModifierKeyDown()) {
             setSelected(object, false, false);
         }
@@ -1401,7 +1392,6 @@ void Canvas::findLassoItemsInArea(Array<WeakReference<Component>>& itemsFound, R
         // Check if path intersects with lasso
         if (con->intersects(lasso.getBounds().translated(-con->getX(), -con->getY()).toFloat())) {
             itemsFound.add(con);
-            setSelected(con, true, false);
         } else if (!ModifierKeys::getCurrentModifiers().isAnyModifierKeyDown()) {
             setSelected(con, false, false);
         }

--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -417,8 +417,10 @@ void Connection::setSegmented(bool isSegmented)
 
 void Connection::setSelected(bool shouldBeSelected)
 {
-    selectedFlag = shouldBeSelected;
-    repaint();
+    if (selectedFlag != shouldBeSelected) {
+        selectedFlag = shouldBeSelected;
+        repaint();
+    }
 }
 
 bool Connection::isSelected()

--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -116,10 +116,7 @@ Connection::~Connection()
 void Connection::changeListenerCallback(ChangeBroadcaster *source)
 {
     if (auto selectedItems = dynamic_cast<SelectedItemSet<WeakReference<Component>>*>(source))
-        if (selectedItems->isSelected(this))
-            setSelected(true);
-        else
-            setSelected(false);
+        setSelected(selectedItems->isSelected(this));
 }
 
 void Connection::valueChanged(Value& v)

--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -415,9 +415,9 @@ void Connection::setSegmented(bool isSegmented)
     repaint();
 }
 
-void Connection::setSelected(bool isSelected)
+void Connection::setSelected(bool shouldBeSelected)
 {
-    selectedFlag = isSelected;
+    selectedFlag = shouldBeSelected;
     repaint();
 }
 

--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -25,6 +25,8 @@ Connection::Connection(Canvas* parent, Iolet* s, Iolet* e, void* oc)
     , inobj(inlet->object)
     , ptr(static_cast<t_fake_outconnect*>(oc))
 {
+    cnv->selectedComponents.addChangeListener(this);
+
     locked.referTo(parent->locked);
     presentationMode.referTo(parent->presentationMode);
     presentationMode.addListener(this);
@@ -92,6 +94,7 @@ Connection::Connection(Canvas* parent, Iolet* s, Iolet* e, void* oc)
 Connection::~Connection()
 {
     cnv->pd->unregisterMessageListener(ptr, this);
+    cnv->selectedComponents.removeChangeListener(this);
 
     if (outlet) {
         outlet->repaint();
@@ -108,6 +111,15 @@ Connection::~Connection()
     if (inobj) {
         inobj->removeComponentListener(this);
     }
+}
+
+void Connection::changeListenerCallback(ChangeBroadcaster *source)
+{
+    if (auto selectedItems = dynamic_cast<SelectedItemSet<WeakReference<Component>>*>(source))
+        if (selectedItems->isSelected(this))
+            setSelected(true);
+        else
+            setSelected(false);
 }
 
 void Connection::valueChanged(Value& v)
@@ -212,7 +224,7 @@ bool Connection::hitTest(int x, int y)
     auto pstart = getStartPoint().toFloat();
     auto pend = getEndPoint().toFloat();
 
-    if (cnv->isSelected(this) && (startReconnectHandle.contains(position) || endReconnectHandle.contains(position))) {
+    if (selectedFlag && (startReconnectHandle.contains(position) || endReconnectHandle.contains(position))) {
         repaint();
         return true;
     }
@@ -386,7 +398,7 @@ void Connection::paint(Graphics& g)
                          isMouseOver(),
                          showDirection,
                          showConnectionOrder,
-                         cnv->isSelected(this),
+                         selectedFlag,
                          getMouseXYRelative(),
                          isHovering,
                          getNumberOfConnections(),
@@ -404,6 +416,17 @@ void Connection::setSegmented(bool isSegmented)
     pushPathState();
     updatePath();
     repaint();
+}
+
+void Connection::setSelected(bool isSelected)
+{
+    selectedFlag = isSelected;
+    repaint();
+}
+
+bool Connection::isSelected()
+{
+    return selectedFlag;
 }
 
 void Connection::mouseMove(MouseEvent const& e)
@@ -477,8 +500,6 @@ void Connection::mouseExit(MouseEvent const& e)
 
 void Connection::mouseDown(MouseEvent const& e)
 {
-    wasSelected = cnv->isSelected(this);
-
     // Deselect all other connection if shift or command is not down
     if (!e.mods.isCommandDown() && !e.mods.isShiftDown()) {
         cnv->deselectAll();
@@ -505,11 +526,11 @@ void Connection::mouseDown(MouseEvent const& e)
 
 void Connection::mouseDrag(MouseEvent const& e)
 {
-    if (wasSelected && startReconnectHandle.contains(e.getMouseDownPosition().toFloat()) && e.getDistanceFromDragStart() > 6) {
+    if (selectedFlag && startReconnectHandle.contains(e.getMouseDownPosition().toFloat()) && e.getDistanceFromDragStart() > 6) {
         cnv->connectingWithDrag = true;
         reconnect(inlet);
     }
-    if (wasSelected && endReconnectHandle.contains(e.getMouseDownPosition().toFloat()) && e.getDistanceFromDragStart() > 6) {
+    if (selectedFlag && endReconnectHandle.contains(e.getMouseDownPosition().toFloat()) && e.getDistanceFromDragStart() > 6) {
         cnv->connectingWithDrag = true;
         reconnect(outlet);
     }
@@ -543,10 +564,10 @@ void Connection::mouseUp(MouseEvent const& e)
         dragIdx = -1;
     }
 
-    if (wasSelected && startReconnectHandle.contains(e.getMouseDownPosition().toFloat()) && startReconnectHandle.contains(e.position)) {
+    if (selectedFlag && startReconnectHandle.contains(e.getMouseDownPosition().toFloat()) && startReconnectHandle.contains(e.position)) {
         reconnect(inlet);
     }
-    if (wasSelected && endReconnectHandle.contains(e.getMouseDownPosition().toFloat()) && endReconnectHandle.contains(e.position)) {
+    if (selectedFlag && endReconnectHandle.contains(e.getMouseDownPosition().toFloat()) && endReconnectHandle.contains(e.position)) {
         reconnect(outlet);
     }
     if (reconnecting.size()) {
@@ -590,7 +611,7 @@ void Connection::reconnect(Iolet* target)
 
     if (Desktop::getInstance().getMainMouseSource().getCurrentModifiers().isShiftDown()) {
         for (auto* c : otherEdge->object->getConnections()) {
-            if (c == this || !cnv->isSelected(c))
+            if (c == this || !c->isSelected())
                 continue;
 
             connections.add(c);
@@ -630,7 +651,7 @@ void Connection::componentMovedOrResized(Component& component, bool wasMoved, bo
     }
 
     // If both inlet and outlet are selected we can just move the connection cord
-    if ((cnv->isSelected(outobj) && cnv->isSelected(inobj)) || cnv->updatingBounds) {
+    if ((outobj->isSelected() && inobj->isSelected()) || cnv->updatingBounds) {
         auto offset = pstart - currentPlan[0];
         for (auto& point : currentPlan)
             point += offset;

--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -24,6 +24,7 @@ class PathUpdater;
 class Connection : public Component
     , public ComponentListener
     , public Value::Listener
+    , public ChangeListener
     , public pd::MessageListener
     , public SettableTooltipClient
 {
@@ -66,6 +67,8 @@ public:
 
     void lookAndFeelChanged() override;
 
+    void changeListenerCallback(ChangeBroadcaster *source) override;
+
     bool hitTest(int x, int y) override;
 
     void mouseDown(MouseEvent const& e) override;
@@ -104,8 +107,9 @@ public:
 
     void receiveMessage(String const& name, int argc, t_atom* argv) override;
 
+    bool isSelected();
+
 private:
-    bool wasSelected = false;
     bool segmented = false;
 
     Array<SafePointer<Connection>> reconnecting;
@@ -114,6 +118,9 @@ private:
 
     int getMultiConnectNumber();
     int getNumberOfConnections();
+
+    void setSelected(bool shouldBeSelected);
+    bool selectedFlag = false;
 
     PathPlan currentPlan;
 

--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -146,8 +146,10 @@ void Object::changeListenerCallback(ChangeBroadcaster *source)
 
 void Object::setSelected(bool shouldBeSelected)
 {
-    selectedFlag = shouldBeSelected;
-    repaint();
+    if (selectedFlag != shouldBeSelected) {
+        selectedFlag = shouldBeSelected;
+        repaint();
+    }
 }
 
 bool Object::isSelected()

--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -141,10 +141,7 @@ void Object::timerCallback()
 void Object::changeListenerCallback(ChangeBroadcaster *source)
 {
     if (auto selectedItems = dynamic_cast<SelectedItemSet<WeakReference<Component>>*>(source))
-        if (selectedItems->isSelected(this))
-            setSelected(true);
-        else
-            setSelected(false);
+        setSelected(selectedItems->isSelected(this));
 }
 
 void Object::setSelected(bool shouldBeSelected)

--- a/Source/Object.h
+++ b/Source/Object.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Utility/ModifierKeyListener.h"
+#include <JuceHeader.h>
 
 class ObjectBase;
 class Iolet;
@@ -17,6 +18,7 @@ class ObjectBoundsConstrainer;
 
 class Object : public Component
     , public Value::Listener
+    , public ChangeListener
     , public Timer
     , private TextEditor::Listener {
 public:
@@ -27,6 +29,8 @@ public:
     ~Object();
 
     void valueChanged(Value& v) override;
+
+    void changeListenerCallback(ChangeBroadcaster *source) override;
 
     void timerCallback() override;
 
@@ -107,6 +111,8 @@ public:
 
     static inline int const minimumSize = 12;
 
+    bool isSelected();
+
 private:
     void initialise();
 
@@ -114,11 +120,15 @@ private:
 
     void openNewObjectEditor();
 
+    void setSelected(bool shouldBeSelected);
+    bool selectedFlag = false;
+
     bool createEditorOnMouseDown = false;
     bool selectionStateChanged = false;
     bool wasLockedOnMouseDown = false;
     bool indexShown = false;
     bool isHvccCompatible = true;
+
 
     ObjectDragState& ds;
 


### PR DESCRIPTION
This PR simplifies the selection system, and uses the built-in broadcaster of SelectedItemSet to update the selection flag of objects & connections.

Further to this there was an object duplication bug that I fixed, that I noticed when testing the system.