### PR TITLE
Fix jiggling connections

### DIFF
--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -655,7 +655,8 @@ void Connection::componentMovedOrResized(Component& component, bool wasMoved, bo
         setBounds(cnv->getBounds().withPosition(0,0));
 
     // if we are moving both in / out object of connection, translate the path
-    if ((!toDraw.isEmpty() && outobj->isSelected() && inobj->isSelected()) || cnv->updatingBounds){
+    // or we are moving the canvas
+    if (!toDraw.isEmpty() && ((outobj->isSelected() && inobj->isSelected()) || cnv->updatingBounds)){
         auto offset = pstart - oldStart;
         toDraw.applyTransform(AffineTransform::translation(offset));
         toDrawBounds = toDraw.getBounds().expanded(8).getSmallestIntegerContainer();

--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -206,9 +206,6 @@ bool Connection::hitTest(int x, int y)
     if (!toDrawBounds.contains(x,y))
         return false;
 
-    if (rateReducer.tooFast())
-        return false;
-
     if (inlet == nullptr || outlet == nullptr)
         return false;
 
@@ -654,8 +651,11 @@ void Connection::componentMovedOrResized(Component& component, bool wasMoved, bo
     auto pstart = getStartPoint();
     auto pend = getEndPoint();
 
+    if (cnv->updatingBounds)
+        setBounds(cnv->getBounds().withPosition(0,0));
+
     // if we are moving both in / out object of connection, translate the path
-    if ((!toDraw.isEmpty() && outobj->isSelected() && inobj->isSelected())){
+    if ((!toDraw.isEmpty() && outobj->isSelected() && inobj->isSelected()) || cnv->updatingBounds){
         auto offset = pstart - oldStart;
         toDraw.applyTransform(AffineTransform::translation(offset));
         toDrawBounds = toDraw.getBounds().expanded(8).getSmallestIntegerContainer();
@@ -670,15 +670,6 @@ void Connection::componentMovedOrResized(Component& component, bool wasMoved, bo
     }
 
     if (currentPlan.size() <= 2) {
-        updatePath();
-        return;
-    }
-
-    // we shouldn't need to do this, this should be translated as well?!
-    if ((outobj->isSelected() && inobj->isSelected()) || cnv->updatingBounds) {
-        auto offset = pstart - currentPlan[0];
-        for (auto& point : currentPlan)
-            point += offset;
         updatePath();
         return;
     }

--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -286,7 +286,7 @@ void Connection::renderConnectionPath(Graphics& g,
 
     if (isSelected) {
         baseColour = isSignal ? signalColour : dataColour;
-    } else if (isMouseOver) {
+    } else if (isHovering) {
         baseColour = isSignal ? signalColour : dataColour;
         baseColour = baseColour.brighter(0.6f);
     }

--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -84,7 +84,7 @@ Connection::Connection(Canvas* parent, Iolet* s, Iolet* e, void* oc)
     valueChanged(presentationMode);
 
     updatePath();
-    repaint();
+    repaintArea();
 
     updateOverlays(cnv->getOverlays());
 
@@ -222,7 +222,7 @@ bool Connection::hitTest(int x, int y)
     auto pend = getEndPoint().toFloat();
 
     if (selectedFlag && (startReconnectHandle.contains(position) || endReconnectHandle.contains(position))) {
-        repaint();
+        repaintArea();
         return true;
     }
 
@@ -381,7 +381,7 @@ void Connection::updateOverlays(int overlay)
 {
     showDirection = overlay & Overlay::Direction;
     showConnectionOrder = overlay & Overlay::Order;
-    repaint();
+    repaintArea();
 }
 
 void Connection::paint(Graphics& g)
@@ -397,7 +397,8 @@ void Connection::paint(Graphics& g)
         getMouseXYRelative(),
         isHovering,
         getNumberOfConnections(),
-        getMultiConnectNumber());
+        getMultiConnectNumber()
+        );
 }
 
 bool Connection::isSegmented()
@@ -410,14 +411,14 @@ void Connection::setSegmented(bool isSegmented)
     segmented = isSegmented;
     pushPathState();
     updatePath();
-    repaint();
+    repaintArea();
 }
 
 void Connection::setSelected(bool shouldBeSelected)
 {
     if (selectedFlag != shouldBeSelected) {
         selectedFlag = shouldBeSelected;
-        repaint();
+        repaintArea();
     }
 }
 
@@ -428,7 +429,7 @@ bool Connection::isSelected()
 
 void Connection::mouseMove(MouseEvent const& e)
 {
-    int n = getClosestLineIdx(e.getPosition().toFloat() + origin, currentPlan);
+    int n = getClosestLineIdx(e.getPosition().toFloat(), currentPlan);
 
     if (isSegmented() && currentPlan.size() > 2 && n > 0) {
         auto line = Line<float>(currentPlan[n - 1], currentPlan[n]);
@@ -444,7 +445,7 @@ void Connection::mouseMove(MouseEvent const& e)
         setMouseCursor(MouseCursor::NormalCursor);
     }
 
-    repaint();
+    repaintArea();
 }
 
 void Connection::mouseEnter(MouseEvent const& e)
@@ -486,13 +487,13 @@ void Connection::mouseEnter(MouseEvent const& e)
     setTooltip(tooltip);
 
     isHovering = true;
-    repaint();
+    repaintArea();
 }
 
 void Connection::mouseExit(MouseEvent const& e)
 {
     isHovering = false;
-    repaint();
+    repaintArea();
 }
 
 void Connection::mouseDown(MouseEvent const& e)
@@ -503,12 +504,12 @@ void Connection::mouseDown(MouseEvent const& e)
     }
 
     cnv->setSelected(this, true);
-    repaint();
+    repaintArea();
 
     if (currentPlan.size() <= 2)
         return;
 
-    int n = getClosestLineIdx(e.position + origin, currentPlan);
+    int n = getClosestLineIdx(e.position, currentPlan);
     if (n < 0)
         return;
 
@@ -549,7 +550,7 @@ void Connection::mouseDrag(MouseEvent const& e)
         }
 
         updatePath();
-        repaint();
+        repaintArea();
     }
 }
 
@@ -678,12 +679,12 @@ void Connection::componentMovedOrResized(Component& component, bool wasMoved, bo
 
 Point<float> Connection::getStartPoint()
 {
-    return Point<float>(outlet->getCanvasBounds().toFloat().getCentreX(), outlet->getCanvasBounds().toFloat().getCentreY() - 0.5f);
+    return outlet->getCanvasBounds().toFloat().getCentre();
 }
 
 Point<float> Connection::getEndPoint()
 {
-    return Point<float>(inlet->getCanvasBounds().toFloat().getCentreX(), inlet->getCanvasBounds().toFloat().getCentreY());
+    return inlet->getCanvasBounds().toFloat().getCentre();
 }
 
 Path Connection::getNonSegmentedPath(Point<float> start, Point<float> end)
@@ -744,15 +745,8 @@ void Connection::updatePath()
     if (!outlet || !inlet)
         return;
 
-    float left = std::min(outlet->getCanvasBounds().getCentreX(), inlet->getCanvasBounds().getCentreX()) - 4;
-    float top = std::min(outlet->getCanvasBounds().getCentreY(), inlet->getCanvasBounds().getCentreY()) - 4;
-    float right = std::max(outlet->getCanvasBounds().getCentreX(), inlet->getCanvasBounds().getCentreX()) + 4;
-    float bottom = std::max(outlet->getCanvasBounds().getCentreY(), inlet->getCanvasBounds().getCentreY()) + 4;
-
-    origin = Rectangle<float>(left, top, right - left, bottom - top).getPosition();
-
-    auto pstart = getStartPoint() - origin;
-    auto pend = getEndPoint() - origin;
+    auto pstart = getStartPoint();
+    auto pend = getEndPoint();
 
     if (!segmented) {
         toDraw = getNonSegmentedPath(pstart, pend);
@@ -764,45 +758,48 @@ void Connection::updatePath()
 
         auto snap = [this](Point<float> point, int idx1, int idx2) {
             if (Line<float>(currentPlan[idx1], currentPlan[idx2]).isVertical()) {
-                currentPlan[idx2].x = point.x + origin.x;
+                currentPlan[idx2].x = point.x;
             } else {
-                currentPlan[idx2].y = point.y + origin.y;
+                currentPlan[idx2].y = point.y;
             }
 
-            currentPlan[idx1] = point + origin;
+            currentPlan[idx1] = point;
         };
 
         snap(pstart, 0, 1);
         snap(pend, static_cast<int>(currentPlan.size() - 1), static_cast<int>(currentPlan.size() - 2));
 
         Path connectionPath;
-        connectionPath.startNewSubPath(pstart.toFloat());
+        connectionPath.startNewSubPath(pstart);
 
         // Add points in between if we've found a path
         for (int n = 1; n < currentPlan.size() - 1; n++) {
             if (connectionPath.contains(currentPlan[n].toFloat()))
                 continue; // ??
 
-            connectionPath.lineTo(currentPlan[n].toFloat() - origin.toFloat());
+            connectionPath.lineTo(currentPlan[n].toFloat());
         }
 
         connectionPath.lineTo(pend.toFloat());
         toDraw = connectionPath.createPathWithRoundedCorners(PlugDataLook::getUseStraightConnections() ? 0.0f : 8.0f);
     }
 
-    repaint();
+    repaintArea();
 
-    auto bounds = toDraw.getBounds().expanded(8);
-    setBounds((bounds + origin).getSmallestIntegerContainer());
-
-    if (bounds.getX() < 0 || bounds.getY() < 0) {
-        toDraw.applyTransform(AffineTransform::translation(-bounds.getX() + 0.5f, -bounds.getY()));
-    }
-
-    offset = { -bounds.getX(), -bounds.getY() };
+    setBounds(cnv->getBounds().withPosition(0,0));
 
     startReconnectHandle = Rectangle<float>(5, 5).withCentre(toDraw.getPointAlongPath(8.5f));
     endReconnectHandle = Rectangle<float>(5, 5).withCentre(toDraw.getPointAlongPath(std::max(toDraw.getLength() - 8.5f, 9.5f)));
+}
+/**
+ * repaint only the active area of the connection
+ */
+void Connection::repaintArea()
+{
+    // repaint current and previous bounds, stops fast movements from building up
+    auto bounds = toDraw.getBounds().toNearestIntEdges().expanded(8);
+    repaint(bounds.getUnion(previousRepaintArea));
+    previousRepaintArea = bounds;
 }
 
 void Connection::findPath()

--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -203,6 +203,9 @@ t_symbol* Connection::getPathState()
 
 bool Connection::hitTest(int x, int y)
 {
+    if (!toDrawBounds.contains(x,y))
+        return false;
+
     if (rateReducer.tooFast())
         return false;
 
@@ -213,9 +216,6 @@ bool Connection::hitTest(int x, int y)
         return false;
 
     if (locked == var(true) || !cnv->connectionsBeingCreated.isEmpty())
-        return false;
-
-    if (!toDrawBounds.contains(x,y))
         return false;
 
     Point<float> position = Point<float>(static_cast<float>(x), static_cast<float>(y));
@@ -490,14 +490,21 @@ void Connection::mouseEnter(MouseEvent const& e)
 
     setTooltip(tooltip);
 
+    stopTimer();
     isHovering = true;
+    repaintArea();
+}
+
+void Connection::timerCallback()
+{
+    stopTimer();
+    isHovering = false;
     repaintArea();
 }
 
 void Connection::mouseExit(MouseEvent const& e)
 {
-    isHovering = false;
-    repaintArea();
+    startTimer(300);
 }
 
 void Connection::mouseDown(MouseEvent const& e)

--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -26,7 +26,8 @@ class Connection : public Component
     , public Value::Listener
     , public ChangeListener
     , public pd::MessageListener
-    , public SettableTooltipClient {
+    , public SettableTooltipClient 
+    , public Timer {
 public:
     int inIdx;
     int outIdx;
@@ -58,6 +59,8 @@ public:
         int connectionNum = 0);
 
     static Path getNonSegmentedPath(Point<float> start, Point<float> end);
+
+    void timerCallback() override;
 
     void paint(Graphics&) override;
     void repaintArea();

--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -35,6 +35,7 @@ public:
     WeakReference<Object> inobj, outobj;
 
     Path toDraw;
+    Rectangle<int> previousRepaintArea = {0,0,0,0};
     String lastId;
 
     Connection(Canvas* parent, Iolet* start, Iolet* end, void* oc);
@@ -58,6 +59,7 @@ public:
     static Path getNonSegmentedPath(Point<float> start, Point<float> end);
 
     void paint(Graphics&) override;
+    void repaintArea();
 
     bool isSegmented();
     void setSegmented(bool segmented);
@@ -90,6 +92,8 @@ public:
     void setPointer(void* ptr);
     void* getPointer();
 
+    Point<float> ctrlPointA, ctrlPointB;
+
     t_symbol* getPathState();
     void pushPathState();
     void popPathState();
@@ -115,6 +119,8 @@ private:
 
     Rectangle<float> startReconnectHandle, endReconnectHandle, endCableOrderDisplay;
 
+    Rectangle<int> adjustedBounds;
+
     int getMultiConnectNumber();
     int getNumberOfConnections();
 
@@ -131,7 +137,7 @@ private:
 
     Canvas* cnv;
 
-    Point<float> origin, offset;
+    Point<float> offset;
 
     int dragIdx = -1;
 
@@ -194,8 +200,8 @@ public:
         if (rateReducer.tooFast())
             return;
 
-        auto ioletPoint = cnv->getLocalPoint((Component*)iolet->object, iolet->getBounds().getCentre());
-        auto cursorPoint = cnv->getLocalPoint(nullptr, e.getScreenPosition());
+        auto ioletPoint = cnv->getLocalPoint((Component*)iolet->object, iolet->getBounds().toFloat().getCentre());
+        auto cursorPoint = cnv->getLocalPoint(nullptr, e.getScreenPosition().toFloat());
 
         auto& startPoint = iolet->isInlet ? cursorPoint : ioletPoint;
         auto& endPoint = iolet->isInlet ? ioletPoint : cursorPoint;

--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -35,6 +35,7 @@ public:
     WeakReference<Object> inobj, outobj;
 
     Path toDraw;
+    Rectangle<int> toDrawBounds = {0,0,0,0};
     Rectangle<int> previousRepaintArea = {0,0,0,0};
     String lastId;
 
@@ -91,8 +92,6 @@ public:
 
     void setPointer(void* ptr);
     void* getPointer();
-
-    Point<float> ctrlPointA, ctrlPointB;
 
     t_symbol* getPathState();
     void pushPathState();
@@ -157,6 +156,8 @@ private:
     std::vector<pd::Atom> lastValue;
     String lastSelector;
     std::mutex lastValueMutex;
+
+    RateReducer rateReducer = RateReducer(90);
 
     friend class ConnectionPathUpdater;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Connection)

--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -36,6 +36,7 @@ public:
     WeakReference<Object> inobj, outobj;
 
     Path toDraw;
+    Point<float> oldStart = {0,0};
     Rectangle<int> toDrawBounds = {0,0,0,0};
     Rectangle<int> previousRepaintArea = {0,0,0,0};
     String lastId;

--- a/Source/Iolet.cpp
+++ b/Source/Iolet.cpp
@@ -47,7 +47,7 @@ Iolet::Iolet(Object* parent, bool inlet)
 Rectangle<int> Iolet::getCanvasBounds()
 {
     // Get bounds relative to canvas, used for positioning connections
-    return getBounds() + object->getPosition();
+    return cnv->getLocalArea(this, getLocalBounds());
 }
 
 bool Iolet::hitTest(int x, int y)


### PR DESCRIPTION
Make each connection the size of the canvas. This simplifies the component, we don't move the connection object, rather redraw only the region of interest.