### PR TITLE
Use floating point position of cursor relative to canvas. This value is not a cast, but a float of the position

### DIFF
--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -194,8 +194,8 @@ public:
         if (rateReducer.tooFast())
             return;
 
-        auto ioletPoint = cnv->getLocalPoint((Component*)iolet->object, iolet->getBounds().getCentre());
-        auto cursorPoint = cnv->getLocalPoint(nullptr, e.getScreenPosition());
+        auto ioletPoint = cnv->getLocalPoint((Component*)iolet->object, iolet->getBounds().toFloat().getCentre());
+        auto cursorPoint = e.getEventRelativeTo(cnv).position;
 
         auto& startPoint = iolet->isInlet ? cursorPoint : ioletPoint;
         auto& endPoint = iolet->isInlet ? ioletPoint : cursorPoint;


### PR DESCRIPTION
If we use the int version of cursor, then the position is related to the canvas position (which is an int).
However, when we zoom the canvas in, we are no longer 1:1 with screen position int. 

This allows the new connection cursor movement to be smooth regardless of the zoom level.