### PR TITLE
move mouse zoom to viewport (TODO: implement per viewport zoom value)

### DIFF
--- a/Source/CanvasViewport.h
+++ b/Source/CanvasViewport.h
@@ -12,6 +12,7 @@
 #include "Connection.h"
 #include "Canvas.h"
 #include "PluginEditor.h"
+#include "PluginProcessor.h"
 
 #include "Utility/SettingsFile.h"
 
@@ -275,6 +276,29 @@ public:
     void enableMousePanning(bool enablePanning)
     {
         panner.enablePanning(enablePanning);
+    }
+
+    void mouseWheelMove(MouseEvent const& e, MouseWheelDetails const& wheel) override
+    {
+        if (e.mods.isCommandDown() && !(editor->pd->isInPluginMode() || cnv->isPalette)) {
+            mouseMagnify(e, 1.0f / (1.0f - wheel.deltaY));
+        }
+        Viewport::mouseWheelMove(e, wheel);
+    }
+
+    void mouseMagnify(MouseEvent const& e, float scrollFactor)
+    {
+        if (!cnv || editor->pd->isInPluginMode())
+            return;
+
+        auto& scale = editor->splitView.isRightTabbarActive() ? editor->splitZoomScale : editor->zoomScale;
+
+        float value = getValue<float>(scale);
+
+        // Apply and limit zoom
+        value = std::clamp(value * scrollFactor, 0.2f, 3.0f);
+
+        scale = value;
     }
 
     void adjustScrollbarBounds()

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -411,32 +411,6 @@ void PluginEditor::parentSizeChanged()
     resized();
 }
 
-void PluginEditor::mouseWheelMove(MouseEvent const& e, MouseWheelDetails const& wheel)
-{
-    if (e.mods.isCommandDown()) {
-        mouseMagnify(e, 1.0f / (1.0f - wheel.deltaY));
-    }
-}
-
-void PluginEditor::mouseMagnify(MouseEvent const& e, float scrollFactor)
-{
-    auto* cnv = getCurrentCanvas();
-
-    if (!cnv || pd->isInPluginMode())
-        return;
-
-    auto event = e.getEventRelativeTo(getCurrentCanvas()->viewport);
-
-    auto& scale = splitView.isRightTabbarActive() ? splitZoomScale : zoomScale;
-
-    float value = getValue<float>(scale);
-
-    // Apply and limit zoom
-    value = std::clamp(value * scrollFactor, 0.2f, 3.0f);
-
-    scale = value;
-}
-
 void PluginEditor::mouseDown(MouseEvent const& e)
 {
     // no window dragging by toolbar in plugin!

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -54,9 +54,6 @@ public:
     void resized() override;
     void parentSizeChanged() override;
 
-    void mouseWheelMove(MouseEvent const& e, MouseWheelDetails const& wheel) override;
-    void mouseMagnify(MouseEvent const& e, float scaleFactor) override;
-
     // For dragging parent window
     void mouseDrag(MouseEvent const& e) override;
     void mouseDown(MouseEvent const& e) override;


### PR DESCRIPTION
By putting the mousewheel zoom into the viewport class, we are able to use the hit-test of the viewport to stop mousewheel from zooming the viewport when outside of its bounds.

Currently there is not per-canvas zoom. This should be added to this, such that we effect the zoom value of cnv->scale, which will stop split-view mode from zooming each others viewports.