### PR TITLE
added remove-connections function

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -1059,6 +1059,25 @@ void Canvas::removeSelection()
     synchroniseSplitCanvas();
 }
 
+void Canvas::removeSelectedConnections()
+{
+    patch.startUndoSequence("Remove Connections");
+
+    for (auto* con : connections) {
+        if (con->isSelected()) {
+            patch.removeConnection(con->outobj->getPointer(), con->outIdx, con->inobj->getPointer(), con->inIdx, con->getPathState());
+        }
+    }
+
+    patch.endUndoSequence("Remove Connections");
+
+    // Load state from pd
+    synchronise();
+    handleUpdateNowIfNeeded();
+
+    synchroniseSplitCanvas();
+}
+
 void Canvas::encapsulateSelection()
 {
     auto selectedBoxes = getSelectionOfType<Object>();

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -99,6 +99,7 @@ public:
 
     void copySelection();
     void removeSelection();
+    void removeSelectedConnections();
     void pasteSelection();
     void duplicateSelection();
 

--- a/Source/Constants.h
+++ b/Source/Constants.h
@@ -166,6 +166,7 @@ enum CommandIDs {
     Duplicate,
     Encapsulate,
     CreateConnection,
+    RemoveConnections,
     SelectAll,
     ShowBrowser,
     ToggleSidebar,

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -984,9 +984,15 @@ void PluginEditor::getCommandInfo(const CommandID commandID, ApplicationCommandI
         break;
     }
     case CommandIDs::CreateConnection: {
-        result.setInfo("Create connection", "Create a connection between selected objects", "General", 0);
+        result.setInfo("Create connection", "Create a connection between selected objects", "Edit", 0);
         result.addDefaultKeypress(75, ModifierKeys::commandModifier);
         result.setActive(canConnect);
+        break;
+    }
+    case CommandIDs::RemoveConnections: {
+        result.setInfo("Remove Connections", "Delete all connections from selection", "Edit", 0);
+        result.addDefaultKeypress(75, ModifierKeys::commandModifier | ModifierKeys::shiftModifier);
+        result.setActive(hasCanvas && !isDragging && !locked && hasSelection);
         break;
     }
     case CommandIDs::SelectAll: {
@@ -1264,6 +1270,11 @@ bool PluginEditor::perform(InvocationInfo const& info)
     case CommandIDs::CreateConnection: {
         cnv = getCurrentCanvas(true);
         return cnv->connectSelectedObjects();
+    }
+    case CommandIDs::RemoveConnections: {
+        cnv = getCurrentCanvas(true);
+        cnv->removeSelectedConnections();
+        return true;
     }
     case CommandIDs::SelectAll: {
         cnv = getCurrentCanvas(true);


### PR DESCRIPTION
the shortcut is ctrl+shift+k, and it doesn't deselect the objects after, so.. yeah, feedback is welcome

i'm not sure about the sync stuff there, i just kept them because that's what the function above was doing and it sounded like a good thing to copy lol

https://user-images.githubusercontent.com/86204514/232652721-857dc426-9bed-4af3-8d90-f11844c909d5.mp4

