### PR TITLE
implement saving outside of PD

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -867,6 +867,23 @@ void Canvas::hideAllActiveEditors()
     }
 }
 
+void Canvas::saveCanvasState()
+{
+    previousCanvasState.clearQuick();
+    for (auto* object : objects) {
+        if (glist_isselected(patch.getPointer(), static_cast<t_gobj*>(object->getPointer()))) {
+            previousCanvasState.add(object);
+        }
+    }
+}
+
+void Canvas::restoreCanvasState()
+{
+    for (auto* obj : previousCanvasState) {
+        setSelected(obj, true);
+    }
+}
+
 void Canvas::copySelection()
 {
     // Tell pd to select all objects that are currently selected

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -97,6 +97,9 @@ public:
 
     void hideAllActiveEditors();
 
+    void saveCanvasState();
+    void restoreCanvasState();
+
     void copySelection();
     void removeSelection();
     void removeSelectedConnections();
@@ -168,6 +171,7 @@ public:
     SelectedItemSet<WeakReference<Component>> selectedComponents;
 
     OwnedArray<Object> objects;
+    Array<Object*> previousCanvasState;
     OwnedArray<Connection> connections;
     OwnedArray<ConnectionBeingCreated> connectionsBeingCreated;
 

--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -290,8 +290,6 @@ void Object::applyBounds()
                 libpd_undo_apply(cnv->patch.getPointer(), obj);
 
                 object->gui->setPdBounds(bounds);
-
-                canvas_dirty(cnv->patch.getPointer(), 1);
             }
 
             patch->endUndoSequence("resize");
@@ -319,6 +317,7 @@ void Object::updateBounds()
 
 void Object::setType(String const& newType, void* existingObject)
 {
+    isValidObject = true;
     // Change object type
     String type = newType.upToFirstOccurrenceOf(" ", false, false);
 

--- a/Source/Object.h
+++ b/Source/Object.h
@@ -113,6 +113,8 @@ public:
 
     bool isSelected();
 
+    bool isValidObject = false;
+
 private:
     void initialise();
 

--- a/Source/Pd/Patch.h
+++ b/Source/Pd/Patch.h
@@ -75,10 +75,11 @@ public:
 
     void setCurrent();
 
-    bool isDirty() const;
+    bool isDirty();
+
+    String savedPatch;
 
     void savePatch(File const& location);
-    void savePatch();
 
     File getCurrentFile() const;
     File getPatchFile() const;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -575,7 +575,8 @@ void PluginEditor::saveProject(std::function<void()> const& nestedCallback)
     }
 
     if (cnv->patch.getCurrentFile().existsAsFile()) {
-        cnv->patch.savePatch();
+        // FIXME: we shouldn't need to give the cnv what it already knows about
+        cnv->patch.savePatch(cnv->patch.getCurrentFile());
         SettingsFile::getInstance()->addToRecentlyOpened(cnv->patch.getCurrentFile());
         nestedCallback();
     } else {

--- a/Source/Standalone/PlugDataApp.cpp
+++ b/Source/Standalone/PlugDataApp.cpp
@@ -198,7 +198,7 @@ void PlugDataWindow::closeAllPatches()
 
     if (canvas) {
         MessageManager::callAsync([this, editor, canvas, patch, deleteFunc]() mutable {
-            if (patch->isDirty()) {
+            if (canvas->patch.isDirty()) {
                 Dialogs::showSaveDialog(&editor->openedDialog, editor, patch->getTitle(),
                     [this, editor, canvas, deleteFunc](int result) mutable {
                         if (!canvas)


### PR DESCRIPTION
Eliminate locking audio thread, however when saving / copying hundreds of objects there is still a small click
I believe this is due to `libpd_copy()`.


