### PR TITLE
use window bounds for saving original bounds, otherwise editor & plug…

### DIFF
--- a/Source/PluginMode.h
+++ b/Source/PluginMode.h
@@ -288,7 +288,7 @@ public:
         
         if(shouldBeBiosk)
         {
-            originalPluginWindowBounds = getBounds();
+            originalPluginWindowBounds = window->getBounds();
             editor->setConstrainer(nullptr);
             window->setUsingNativeTitleBar(false);
             desktopWindow = window->getPeer();


### PR DESCRIPTION
…inmode are both 0,0 position