### PR TITLE
messbox fixes

### DIFF
--- a/Source/Objects/MessboxObject.h
+++ b/Source/Objects/MessboxObject.h
@@ -43,10 +43,6 @@ public:
 
         addAndMakeVisible(editor);
 
-        editor.onFocusLost = [this]() {
-            hideEditor();
-        };
-
         resized();
         repaint();
 
@@ -146,7 +142,7 @@ public:
             break;
         }
         case hash("bold"): {
-            if (atoms.size() > 0 && atoms[0].isFloat())
+            if (atoms.size() >= 1 && atoms[0].isFloat())
                 bold = atoms[0].getFloat();
             break;
         }
@@ -200,7 +196,10 @@ public:
         auto words = StringArray::fromTokens(symbols.trim(), true);
         for (auto const& word : words) {
             atoms.emplace_back();
-            if (word.containsOnly("0123456789e.-+e") && word != "-") {
+            if (word.containsOnly("0123456789e.-+") &&
+                    !word.endsWith("-") && !word.containsOnly(".-+e") &&
+                    !word.startsWith("e") && !word.endsWith("e") &&
+                    !word.startsWith("+") && !word.endsWith("+")) {
                 SETFLOAT(&atoms.back(), word.getFloatValue());
             } else {
                 SETSYMBOL(&atoms.back(), pd->generateSymbol(word));
@@ -208,10 +207,7 @@ public:
         }
 
         if (atoms.size()) {
-            auto* sym = atom_getsymbol(&atoms[0]);
-            atoms.erase(atoms.begin());
-
-            outlet_anything(static_cast<t_object*>(ptr)->ob_outlet, sym, atoms.size(), atoms.data());
+            outlet_anything(static_cast<t_object*>(ptr)->ob_outlet, pd->generateSymbol("list"), atoms.size(), atoms.data());
         }
     }
 


### PR DESCRIPTION
1. `editor.onFocusLost = [this]() {hideEditor();};` was making this annoying thing where when you click outside of the object (in run mode) you have to ctrl+click to get back to the editor.. but i'm not sure if that's universal or just me
2. fixed the non-numbers getting converted to numbers issue
3. then got caught up for hours trying to figure out why it outputs 0 when you give it any float, so turns out it was the selector being wrong. list fixes this