### PR TITLE
sync when canvas gets "cut" message

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -1562,6 +1562,7 @@ void Canvas::receiveMessage(String const& symbol, int argc, t_atom* argv)
     case hash("numbox"):
     case hash("connect"):
     case hash("clear"):
+    case hash("cut"):
     case hash("donecanvasdialog"): {
         // This will trigger an asyncupdater, so it's thread-safe to do this here
         synchronise();


### PR DESCRIPTION
this way it works if you do it in graphs or in the visible canvas. one thing that's weird is that the canvas loses its ability to duplicate objects after you use the `mouse` message :mouse: [edit: needs a `mouseup` to get it to duplicate again]

https://github.com/plugdata-team/plugdata/assets/86204514/7de316fd-aaed-4c69-b8d8-75cba48ddf29

