### PR TITLE
smol documentation fixes

### DIFF
--- a/Resources/Documentation/ELSE/args.md
+++ b/Resources/Documentation/ELSE/args.md
@@ -26,7 +26,7 @@ inlets:
 outlets:
   1st:
   - type: anything
-    description: symbol, float or list, depending on the given arguments - or bang if no arguments are given to the parent patch (as in the help patch)
+    description: arguments given in the parent patch (bang is empty list)
 
 draft: false
 ---

--- a/Resources/Documentation/vanilla/pdcontrol.md
+++ b/Resources/Documentation/vanilla/pdcontrol.md
@@ -18,7 +18,7 @@ inlets:
 outlets:
   1st:
   - type: list
-    description: list of args, dir symbol of visibility float
+    description: list of args, dir symbol, or visibility float
 draft: false
 ---
 pdcontrol lets you open a URL in a web browser or communicate with the patch to get its owning directory, arguments or its visible/invisible state.

--- a/Resources/Documentation/vanilla/select.md
+++ b/Resources/Documentation/vanilla/select.md
@@ -17,7 +17,7 @@ inlets:
     description: input to compare to arguments
   2nd:
   - type: float/symbol
-    description: if there's one argument, an inlet is created to update it
+    description: update argument
 outlets:
   nth:
   - type: bang


### PR DESCRIPTION
in [select] the inlet is only visible if there is one argument so we don't need the conditional
