### PR TITLE
fix closing a tab when it has unsaved changes, (its dirty)

### DIFF
--- a/Source/TabBarButtonComponent.cpp
+++ b/Source/TabBarButtonComponent.cpp
@@ -30,15 +30,15 @@ TabBarButtonComponent::TabBarButtonComponent(TabComponent* tabComponent, String 
             return;
 
         if (cnv) {
-            MessageManager::callAsync([this, cnv = SafePointer(cnv), editor = SafePointer(editor)]() mutable {
+            MessageManager::callAsync([cnv = SafePointer(cnv), editor = SafePointer(editor)]() mutable {
                 // Don't show save dialog, if patch is still open in another view
                 if (cnv && cnv->patch.isDirty()) {
-                    Dialogs::showSaveDialog(&editor->openedDialog, this, cnv->patch.getTitle(),
-                        [this, cnv, editor](int result) mutable {
+                    Dialogs::showSaveDialog(&editor->openedDialog, editor, cnv->patch.getTitle(),
+                        [cnv, editor](int result) mutable {
                             if (!cnv)
                                 return;
                             if (result == 2)
-                                editor->saveProject([this, cnv, editor]() mutable { editor->closeTab(cnv); });
+                                editor->saveProject([cnv, editor]() mutable { editor->closeTab(cnv); });
                             else if (result == 1)
                                 editor->closeTab(cnv);
                         });


### PR DESCRIPTION
the object given to the lambda to show into was the tabbarbutton, should be the editor