### PR TITLE
Untitled-N new patch now uses lowest number

### DIFF
--- a/Source/Pd/Patch.cpp
+++ b/Source/Pd/Patch.cpp
@@ -113,6 +113,7 @@ void Patch::savePatch(File const& location)
 
     if (auto patch = ptr.get<t_glist>()) {
         setTitle(filename);
+        untitledPatchNum = 0;
         canvas_dirty(patch.get(), 0);
 
         libpd_savetofile(patch.get(), file, dir);
@@ -160,6 +161,7 @@ void Patch::savePatch()
 
     if (auto patch = ptr.get<t_glist>()) {
         setTitle(filename);
+        untitledPatchNum = 0;
         canvas_dirty(patch.get(), 0);
 
         libpd_savetofile(patch.get(), file, dir);

--- a/Source/Pd/Patch.h
+++ b/Source/Pd/Patch.h
@@ -121,6 +121,8 @@ public:
     bool openInPluginMode = false;
     int splitViewIndex = 0;
 
+    int untitledPatchNum = 0;
+
 private:
     File currentFile;
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -527,8 +527,24 @@ void PluginEditor::fileDragExit(StringArray const&)
 
 void PluginEditor::newProject()
 {
+    // find the lowest `Untitled-N` number, for the new patch title
+    int lowestNumber= 1;
+    Array<int> patchNumbers;
+    for (auto patch : pd->patches) {
+        patchNumbers.add(patch->untitledPatchNum);
+    }
+    // all patches with an untitledPatchNum of 0 are saved patches (at least once)
+    patchNumbers.removeAllInstancesOf(0);
+    patchNumbers.sort();
+
+    for (auto number : patchNumbers) {
+        if (number <= lowestNumber)
+            lowestNumber = number + 1;
+    }
+
     auto patch = pd->loadPatch(pd::Instance::defaultPatch);
-    patch->setTitle("Untitled-" + String(numUntitled++));
+    patch->untitledPatchNum = lowestNumber;
+    patch->setTitle("Untitled-" + String(lowestNumber));
 }
 
 void PluginEditor::openProject()

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -158,8 +158,6 @@ private:
 #if JUCE_MAC
     Rectangle<int> unmaximisedSize;
 #endif
-    
-    int numUntitled = 1;
 
     bool isMaximised = false;
     bool isDraggingFile = false;


### PR DESCRIPTION
Instead of counting up the `Untitled-N` patches, we use the lowest missing number given the current loaded unsaved patches:

[](https://github.com/plugdata-team/plugdata/assets/12004932/1df181e6-a430-4771-b196-55aafd6b054a)



