### PR TITLE
Virtual MIDI input must be activated (fixes #986)

### DIFF
--- a/Source/Standalone/PlugDataWindow.h
+++ b/Source/Standalone/PlugDataWindow.h
@@ -431,6 +431,7 @@ private:
 
 #if !JUCE_WINDOWS
         if (auto* newIn = MidiInput::createNewDevice("to plugdata", &player).release()) {
+            newIn->start();
             customMidiInputs.add(newIn);
         }
 #endif


### PR DESCRIPTION
Fix for "to plugdata" port not working, as discussed in #986.