### PR TITLE
Fixed botched logic in MidiDeviceManager::setMidiDeviceEnabled()

### DIFF
--- a/Source/Utility/MidiDeviceManager.h
+++ b/Source/Utility/MidiDeviceManager.h
@@ -179,12 +179,14 @@ struct MidiDeviceManager : public ChangeListener
                 toPlugdata->stop();
             }
         }
-        else if(isInput && shouldBeEnabled != isMidiDeviceEnabled(false, identifier))
+        else if(isInput)
         {
-            ProjectInfo::getDeviceManager()->setMidiInputDeviceEnabled(identifier, shouldBeEnabled);
+            if (shouldBeEnabled != isMidiDeviceEnabled(true, identifier)) {
+                ProjectInfo::getDeviceManager()->setMidiInputDeviceEnabled(identifier, shouldBeEnabled);
+            }
         }
-        else {
-            if(shouldBeEnabled != isMidiDeviceEnabled(false, identifier))
+        else if(shouldBeEnabled != isMidiDeviceEnabled(false, identifier)) {
+            if(shouldBeEnabled)
             {
                 auto* device = midiOutputs.add(MidiOutput::openDevice(identifier));
                 if(device) device->startBackgroundThread();


### PR DESCRIPTION
This was badly broken. I spare you the details, you can find them in the commit message.