### PR TITLE
Midi port system improvements

### DIFF
--- a/Source/Dialogs/MIDISettingsPanel.h
+++ b/Source/Dialogs/MIDISettingsPanel.h
@@ -81,10 +81,10 @@ private:
         
         
 
-        auto midiInputDevices = ProjectInfo::getMidiDeviceManager()->getInputDevices();
+        auto midiInputDevices = ProjectInfo::getMidiDeviceManager()->getInputDevicesUnsorted();
         auto midiInputProperties = Array<PropertiesPanel::Property*>();
 
-        auto midiOutputDevices = ProjectInfo::getMidiDeviceManager()->getOutputDevices();
+        auto midiOutputDevices = ProjectInfo::getMidiDeviceManager()->getOutputDevicesUnsorted();
         auto midiOutputProperties = Array<PropertiesPanel::Property*>();
         
         for (auto& deviceInfo : midiInputDevices) {

--- a/Source/Dialogs/MIDISettingsPanel.h
+++ b/Source/Dialogs/MIDISettingsPanel.h
@@ -81,10 +81,10 @@ private:
         
         
 
-        auto midiInputDevices = ProjectInfo::getMidiDeviceManager()->getInputDevicesUnsorted();
+        auto midiInputDevices = ProjectInfo::getMidiDeviceManager()->getInputDevicesUnfiltered();
         auto midiInputProperties = Array<PropertiesPanel::Property*>();
 
-        auto midiOutputDevices = ProjectInfo::getMidiDeviceManager()->getOutputDevicesUnsorted();
+        auto midiOutputDevices = ProjectInfo::getMidiDeviceManager()->getOutputDevicesUnfiltered();
         auto midiOutputProperties = Array<PropertiesPanel::Property*>();
         
         for (auto& deviceInfo : midiInputDevices) {

--- a/Source/Dialogs/MIDISettingsPanel.h
+++ b/Source/Dialogs/MIDISettingsPanel.h
@@ -61,6 +61,7 @@ public:
         addAndMakeVisible(midiProperties);
 
         deviceManager.addChangeListener(this);
+        ProjectInfo::getMidiDeviceManager()->updateMidiDevices();
         updateDevices();
     }
 


### PR DESCRIPTION
(As sketched out in https://github.com/plugdata-team/plugdata/pull/991#issuecomment-1659778286.) This is a first stab at improving the new system of MIDI ports which recently landed in the develop branch (which already is a big improvement, but it can be made better). Specifically, instead of presenting the user with unwieldy lists of *all* available MIDI input and output ports, it uses separate curated lists which only have the ports that the user actually enabled in the MIDI settings, making it much easier to deal with port selection on a system with lots of attached MIDI devices.

The present PR already goes a long way towards providing something that's similar to vanilla Pd's MIDI port system. It should be clean and flexible enough for future extensions and working towards that goal, but also provides a more workable and user-friendly solution to keep users happy for the time being.

Only tested on Linux so far.