### PR TITLE
Massage workflow to skip ftp upload and macOS sign/notarize if credentials are missing

### DIFF
--- a/.github/scripts/package-macOS.sh
+++ b/.github/scripts/package-macOS.sh
@@ -49,6 +49,8 @@ build_flavor()
   rm -r $TMPDIR
 }
 
+if [ -n "$AC_USERNAME" ]; then
+
 # Sign app with hardened runtime and audio entitlement
 /usr/bin/codesign --force -s "Developer ID Application: Timothy Schoen (7SV7JPRR2L)" --options runtime --entitlements ./Resources/Installer/Entitlements.plist ./Plugins/Standalone/*.app
 
@@ -59,6 +61,8 @@ build_flavor()
 /usr/bin/codesign --force -s "Developer ID Application: Timothy Schoen (7SV7JPRR2L)" ./Plugins/LV2/plugdata-fx.lv2/libplugdata-fx.so
 /usr/bin/codesign --force -s "Developer ID Application: Timothy Schoen (7SV7JPRR2L)" ./Plugins/CLAP/plugdata.clap/Contents/MacOS/plugdata
 /usr/bin/codesign --force -s "Developer ID Application: Timothy Schoen (7SV7JPRR2L)" ./Plugins/CLAP/plugdata-fx.clap/Contents/MacOS/plugdata-fx
+
+fi
 
 # # try to build VST3 package
 if [[ -d $VST3 ]]; then
@@ -147,6 +151,13 @@ productbuild --resources ./ --distribution ${TARGET_DIR}/distribution.xml --pack
 
 rm ${TARGET_DIR}/distribution.xml
 rm -r $PKG_DIR
+
+if [ -z "$AC_USERNAME" ]; then
+    echo "No user name, skipping sign/notarize"
+    # pretend that we signed the package and bail out
+    mv ${PRODUCT_NAME}.pkg ${PRODUCT_NAME}-MacOS-Universal.pkg
+    exit 0
+fi
 
 # Sign installer
 productsign -s "Developer ID Installer: Timothy Schoen (7SV7JPRR2L)" ${PRODUCT_NAME}.pkg ${PRODUCT_NAME}-MacOS-Universal.pkg

--- a/.github/scripts/upload-ftp.sh
+++ b/.github/scripts/upload-ftp.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ -z "$FTP_USERNAME" ]; then
+    echo "No user name, skipping ftp upload"
+    exit 0
+fi
+
 git config --global --add safe.directory /__w/plugdata/plugdata
 
 FILE=$1

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,8 +29,19 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_OFELIA=1
 
+    - name: Check for Code-Signing secrets
+      id: secret-check
+      shell: bash
+      run: |
+        if [ "${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}" != '' ]; then
+          echo "available=true" >> $GITHUB_OUTPUT;
+        else
+          echo "available=false" >> $GITHUB_OUTPUT;
+        fi
+
     - name: Import Code-Signing Certificates
       uses: figleafteam/import-codesign-certs@v2
+      if: ${{ steps.secret-check.outputs.available == 'true' }}
       with: 
         p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
         p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
As discussed, this skips any steps in the workflow which require special secrets if those aren't provided.

This works for me on my fork, I don't get any upload and codesign errors in the build logs any more, and the macOS build also goes through fine. I can't test this with secrets, since I don't have any. :) But we'll see whether it still works as before in your repo once you merge this and we check the CI build logs.