### PR TITLE
Revert "Fixed audio input and output ports not updating when enabling/disabling from settings"

### DIFF
--- a/Source/Dialogs/AudioSettingsPanel.h
+++ b/Source/Dialogs/AudioSettingsPanel.h
@@ -312,7 +312,6 @@ private:
                 inputProperties.add(new ChannelToggleProperty(channel, enabled, [this, idx](bool isEnabled) {
                     setup.useDefaultInputChannels = false;
                     setup.inputChannels.setBit(idx, isEnabled);
-                    updateConfig();
                 }));
                 idx++;
             }
@@ -341,7 +340,6 @@ private:
                 outputProperties.add(new ChannelToggleProperty(channel, enabled, [this, idx](bool isEnabled) {
                     setup.useDefaultOutputChannels = false;
                     setup.outputChannels.setBit(idx, isEnabled);
-                    updateConfig();
                 }));
                 idx++;
             }


### PR DESCRIPTION
I'd like commit a8ae939aca4dc7d8cb5cc2a9565822957e24fe86 to be reverted, which is all this PR does.

I'm not sure what issue this commit is supposed to fix, because I don't see any of the misbehavior described in the commit message. Tim, do you remember?

The problem is that this commit causes a severe regression in that plugdata completely locks up when changing audio devices in some situations. Specifically, try switching both audio output and input from ALSA (the default setting in Linux) with the default sample rate of 44100 to Jack (running at 48000 Hz). This locks up the application every time I try to do this, so it's 100% reproducible. Reverting the commit reliably makes the regression go away.