### PR TITLE
Check that chosen sample rate is set properly when changing devices

### DIFF
--- a/Source/Dialogs/AudioSettingsPanel.h
+++ b/Source/Dialogs/AudioSettingsPanel.h
@@ -242,6 +242,14 @@ private:
                 }
             }
 
+            // also make sure that setup.sampleRate is set to a supported rate
+            if (!sampleRates.contains(setup.sampleRate)) {
+                for (auto& rate : sampleRates) {
+                  setup.sampleRate = rate;
+                  break;
+                }
+            }
+
             StringArray bufferSizeStrings;
             for (auto& size : bufferSizes) {
                 auto sizeAsString = String(size);


### PR DESCRIPTION
This makes sure that the audio setup shows a supported sample rate when switching devices. E.g., when switching from ALSA @ 44.1KHz to Jack @ 48kHz, without this PR the audio setup still shows the wrong old sample rate, which can cause issues because Jack will refuse a rate which differs from what it is set to. This PR fixes that.