### PR TITLE
Fix gcc warnings

### DIFF
--- a/Libraries/cyclone/cyclone_objects/binaries/control/cycle.c
+++ b/Libraries/cyclone/cyclone_objects/binaries/control/cycle.c
@@ -84,7 +84,7 @@ static void cycle_list(t_cycle *x, t_symbol *s, int ac, t_atom *av)
 
 static void cycle_anything(t_cycle *x, t_symbol *s, int ac, t_atom *av)
 {
-    if (s && s != &s)
+    if (s /*&& s != &s*/)
     {
        if(ac > 1)  cycle_symbol(x, s);  /* CHECKED */
        else

--- a/Libraries/cyclone/cyclone_objects/binaries/control/spell.c
+++ b/Libraries/cyclone/cyclone_objects/binaries/control/spell.c
@@ -20,7 +20,7 @@ static void spell_fill(t_spell *x, int cnt){
 }
 
 /* CHECKED: chars are spelled as signed */
-static int spell_out(t_spell *x, char *ptr, int flush)
+static int spell_out(t_spell *x, const char *ptr, int flush)
 {
     int cnt = 0;
     while (*ptr)

--- a/Libraries/cyclone/cyclone_objects/binaries/control/tosymbol.c
+++ b/Libraries/cyclone/cyclone_objects/binaries/control/tosymbol.c
@@ -80,7 +80,7 @@ static int tosymbol_parse(t_symbol *s, int ac, t_atom *av, t_symbol *separator,
     bp += len;
     if (ac && nleft > 0)
     {
-	char *sepstring = (separator ?
+	const char *sepstring = (separator ?
 			   separator->s_name : tosymbol_defseparator);
 	while (ac--)
 	{

--- a/Libraries/cyclone/cyclone_objects/binaries/cyclone_lib.c
+++ b/Libraries/cyclone/cyclone_objects/binaries/cyclone_lib.c
@@ -645,17 +645,17 @@ void print_cyclone(t_cyclone *x){
     post(":: Cyclone %d.%d-%d; Released june 8th 2022", cyclone_major, cyclone_minor, cyclone_bugfix);
     post(":: License: BSD-3-Clause (aka Revised BSD License)");
     post(":: Copyright © 2003-2021 - Krzysztof Czaja, Hans-Christoph Steiner,");
-    post(":: Fred Jan Kraan, Alexandre Porres, Derek Kwan, Matt Barber\n\:: and others.");
+    post(":: Fred Jan Kraan, Alexandre Porres, Derek Kwan, Matt Barber\n:: and others.");
     post(":: -----------------------------------------------------------------");
     if((major > min_major)
        || (major == min_major && minor > min_minor)
        || (major == min_major && minor == min_minor && bugfix >= min_bugfix))
-        post(":: Cyclone %d.%d-%d needs at least Pd %d.%d-%d\n\::   (you have %d.%d-%d, you're good!)",
+        post(":: Cyclone %d.%d-%d needs at least Pd %d.%d-%d\n::   (you have %d.%d-%d, you're good!)",
              cyclone_major, cyclone_minor, cyclone_bugfix,
              min_major, min_minor, min_bugfix,
              major, minor, bugfix);
     else
-        pd_error(x, ":: Cyclone %d.%d-%d needs at least Pd %d.%d-%d\n\:: (you have %d.%d-%d, please upgrade!)",
+        pd_error(x, ":: Cyclone %d.%d-%d needs at least Pd %d.%d-%d\n:: (you have %d.%d-%d, please upgrade!)",
             cyclone_major, cyclone_minor, cyclone_bugfix,
             min_major, min_minor, min_bugfix,
             major, minor, bugfix);
@@ -665,7 +665,7 @@ void print_cyclone(t_cyclone *x){
     post(":: [==~], [>=~] and [>~]");
     post("::   - B) Added %s", cyclone_dir);
     post(":: to Pd's path so the other objects can be loaded too");
-    post(":: but use [declare -path cyclone] to guarantee search priority\n\:: in the patch");
+    post(":: but use [declare -path cyclone] to guarantee search priority\n:: in the patch");
     post("--------------------------------------------------------------------");
     post("");
 }

--- a/Libraries/cyclone/shared/control/gui.c
+++ b/Libraries/cyclone/shared/control/gui.c
@@ -249,7 +249,7 @@ static int hammergui_setup(void)
     ps__vised = gensym("_vised");
     if (ps_hashhammergui->s_thing)
     {
-	char *cname = class_getname(*ps_hashhammergui->s_thing);
+	const char *cname = class_getname(*ps_hashhammergui->s_thing);
 #ifdef HAMMERGUI_DEBUG
 	fprintf(stderr,
 		"'%s' already registered as the global hammergui sink \n",

--- a/Source/Objects/BicoeffObject.h
+++ b/Source/Objects/BicoeffObject.h
@@ -570,7 +570,7 @@ public:
                 auto* patch = object->cnv->patch.getPointer().get();
                 if (!patch) return;
                 
-                pd->sendDirectMessage(gobj.get(), "dim", { width, height });
+                pd->sendDirectMessage(gobj.get(), "dim", { (float)width, (float)height });
             }
             
             object->updateBounds();
@@ -599,7 +599,7 @@ public:
                 return;
 
             libpd_moveobj(patch, gobj.get(), b.getX(), b.getY());
-            pd->sendDirectMessage(gobj.get(), "dim", { b.getWidth() - 1, b.getHeight() - 1 });
+            pd->sendDirectMessage(gobj.get(), "dim", { (float)b.getWidth() - 1, (float)b.getHeight() - 1 });
         }
 
         graph.saveProperties();

--- a/Source/Objects/KeyboardObject.h
+++ b/Source/Objects/KeyboardObject.h
@@ -383,7 +383,7 @@ public:
         } else if (value.refersToSameSourceAs(toggleMode)) {
             auto toggle = getValue<int>(toggleMode);
             if (auto obj = ptr.get<void>())
-                pd->sendDirectMessage(obj.get(), "toggle", { toggle });
+                pd->sendDirectMessage(obj.get(), "toggle", { (float)toggle });
             keyboard.setToggleMode(toggle);
         }
     }


### PR DESCRIPTION
This is a first batch of fixes for #1037. Fixes all the warnings in the plugdata repo itself, minus the the JUCE deprecated warnings, and the bit field issue in https://github.com/plugdata-team/plugdata/commit/4732f349b4be536ca19ca310fa33efa957bc08e4, as I'm not really sure what the proper fix is.

This slashes a good part of the gcc warnings when compiling plugdata, so the build log is a lot less noisy.