### PR TITLE
Fail gracefully/don't crash if a library path does not exist

### DIFF
--- a/Source/Pd/Library.cpp
+++ b/Source/Pd/Library.cpp
@@ -63,7 +63,11 @@ void Library::updateLibrary()
     for (auto path : pathTree) {
         auto filePath = path.getProperty("Path").toString();
 
-        for (auto const& file : OSUtils::iterateDirectory(File(filePath), false, true)) {
+        auto file = File(filePath);
+        if (!file.exists() || !file.isDirectory())
+            continue;
+
+        for (auto const& file : OSUtils::iterateDirectory(file, false, true)) {
             if (file.hasFileExtension(".pd")) {
                 auto filename = file.getFileNameWithoutExtension();
                 if (!filename.startsWith("help-") || filename.endsWith("-help")) {


### PR DESCRIPTION
This fixes a `Unhandled exception at 0x00007FF91F424B2C in plugdata.exe: Microsoft C++ exception: std::filesystem::filesystem_error at memory location 0x000000F62EEFEA90.` on Win64 during launch of the application (63ace90ec96841d2af673cb4506fc20e3fce2c24)