### PR TITLE
use alpha when moving tabs, because of overflow menu using visisbilit…

### DIFF
--- a/Source/TabBarButtonComponent.cpp
+++ b/Source/TabBarButtonComponent.cpp
@@ -98,18 +98,15 @@ void TabBarButtonComponent::mouseExit(MouseEvent const& e)
 
 void TabBarButtonComponent::tabTextChanged(String const& newCurrentTabName)
 {
-    isDirty = true; 
 }
 
 void TabBarButtonComponent::lookAndFeelChanged()
 {
-    isDirty = true;
 }
 
 void TabBarButtonComponent::resized()
 {
     closeTabButton.setCentrePosition(getBounds().getCentre().withX(getBounds().getWidth() - 15).translated(0, -1));
-    isDirty = true;
 }
 
 ScaledImage TabBarButtonComponent::generateTabBarButtonImage()
@@ -191,18 +188,13 @@ void TabBarButtonComponent::mouseDown(MouseEvent const& e)
 
 void TabBarButtonComponent::mouseDrag(MouseEvent const& e)
 {
-    if(e.getDistanceFromDragStart() > 10) {
-        //setVisible(false);
+    if(e.getDistanceFromDragStart() > 10 && !isDragging) {
+        isDragging = true;
         closeTabButton.setVisible(false);
         var tabIndex = getIndex();
         auto dragContainer = ZoomableDragAndDropContainer::findParentDragContainerFor(this);
 
-        //if (isDirty) {
-            tabImage = generateTabBarButtonImage();
-        //    isDirty = false;
-        //}
-    
-        //auto offset = e.getPosition() * -1 - Point<int>(boundsOffset,boundsOffset);
+        tabImage = generateTabBarButtonImage();
         dragContainer->startDragging(tabIndex, this, tabImage, true, nullptr);
     }
 }
@@ -210,6 +202,7 @@ void TabBarButtonComponent::mouseDrag(MouseEvent const& e)
 void TabBarButtonComponent::mouseUp(MouseEvent const& e)
 {
     setVisible(true);
+    isDragging = false;
 }
 
 // FIXME: we are only using this to draw the DnD tab image

--- a/Source/TabBarButtonComponent.h
+++ b/Source/TabBarButtonComponent.h
@@ -41,5 +41,5 @@ private:
     TextButton closeTabButton;
     const int boundsOffset = 10;
     ScaledImage tabImage;
-    bool isDirty = true;
+    bool isDragging = false;
 };

--- a/Source/Tabbar.cpp
+++ b/Source/Tabbar.cpp
@@ -62,7 +62,7 @@ void ButtonBar::changeListenerCallback(ChangeBroadcaster* source)
     if (&ghostTabAnimator == source) {
         if (!ghostTabAnimator.isAnimating()) {
             ghostTab->setVisible(false);
-            getTabButton(ghostTabIdx)->setVisible(true);
+            getTabButton(ghostTabIdx)->setAlpha(1.0f);
         }
     }
 }
@@ -70,8 +70,8 @@ void ButtonBar::changeListenerCallback(ChangeBroadcaster* source)
 void ButtonBar::itemDropped(SourceDetails const& dragSourceDetails)
 {
     auto animateTabToPosition = [this](){
-        getTabButton(ghostTabIdx)->setVisible(false);
-        ghostTabAnimator.animateComponent(ghostTab.get(), ghostTab->getBounds().withPosition(Point<int>(ghostTab->getIndex() * (getWidth() / getNumTabs()), 0)), 1.0f, 200, false, 3.0f, 0.0f);
+        getTabButton(ghostTabIdx)->setAlpha(0.0f);
+        ghostTabAnimator.animateComponent(ghostTab.get(), ghostTab->getBounds().withPosition(Point<int>(ghostTab->getIndex() * (getWidth() / getNumVisibleTabs()), 0)), 1.0f, 200, false, 3.0f, 0.0f);
     };
 
     // this has a whole lot of code replication from ResizableTabbedComponent.cpp, good candidate for refactoring!
@@ -81,7 +81,7 @@ void ButtonBar::itemDropped(SourceDetails const& dragSourceDetails)
         auto sourceTabButton = static_cast<TabBarButtonComponent*>(dragSourceDetails.sourceComponent.get());
         int sourceTabIndex = sourceTabButton->getIndex();
         auto sourceTabContent = sourceTabButton->getTabComponent();
-        int sourceNumTabs = sourceTabContent->getNumTabs();
+        int sourceNumTabs = sourceTabContent->getNumVisibleTabs();
 
         inOtherSplit = false;
         // we remove the ghost tab, which is NOT a proper tab, (it only a tab, and doesn't have a viewport)
@@ -94,7 +94,7 @@ void ButtonBar::itemDropped(SourceDetails const& dragSourceDetails)
         owner.setCurrentTabIndex(ghostTabIdx);
 
         sourceTabContent->removeTab(sourceTabIndex);
-        auto sourceCurrentIndex = sourceTabIndex > (sourceTabContent->getNumTabs() - 1) ? sourceTabIndex - 1 : sourceTabIndex;
+        auto sourceCurrentIndex = sourceTabIndex > (sourceTabContent->getNumVisibleTabs() - 1) ? sourceTabIndex - 1 : sourceTabIndex;
         sourceTabContent->setCurrentTabIndex(sourceCurrentIndex);
 
         if (sourceNumTabs < 2) {
@@ -129,7 +129,7 @@ void ButtonBar::itemDragEnter(SourceDetails const& dragSourceDetails)
         // if this tabbar is DnD on itself, we don't need to add a new tab
         // we move the existing tab
         if (tab->getTabComponent() == &owner) {
-            tab->setVisible(false);
+            tab->setAlpha(0.0f);
             inOtherSplit = false;
             ghostTabIdx = tab->getIndex();
             ghostTab->setTabButtonToGhost(tab);
@@ -137,12 +137,15 @@ void ButtonBar::itemDragEnter(SourceDetails const& dragSourceDetails)
             // we calculate where the tab will go when its added,
             // so we need to add 1 to the number of existing tabs
             // to take the added tab into account
-            auto targetTabPos = getWidth() / (getNumTabs() + 1);
+
+            // WARNING: because we are using the overflow (show extra items menu)
+            // we need to find out how many tabs are visible, not how many there are all together
+            auto targetTabPos = getWidth() / (getNumVisibleTabs() + 1);
             auto tabPos = dragSourceDetails.localPosition.getX() / targetTabPos;
             inOtherSplit = true;
             addTab(tab->getButtonText(), Colours::transparentBlack, tabPos);
             auto* fakeTab = getTabButton(tabPos);
-            fakeTab->setVisible(false);
+            fakeTab->setAlpha(0.0f);
             ghostTab->setTabButtonToGhost(fakeTab);
             ghostTabIdx = tabPos;
         }
@@ -154,7 +157,7 @@ void ButtonBar::itemDragExit(SourceDetails const& dragSourceDetails)
 {
     if (auto* tab = dynamic_cast<TabBarButtonComponent*>(dragSourceDetails.sourceComponent.get())) {
         ghostTab->setVisible(false);
-        tab->setVisible(false);
+        tab->setAlpha(0.0f);
         if (inOtherSplit) {
             inOtherSplit = false;
             removeTab(ghostTabIdx, true);
@@ -162,11 +165,21 @@ void ButtonBar::itemDragExit(SourceDetails const& dragSourceDetails)
     }
 }
 
+int ButtonBar::getNumVisibleTabs()
+{
+    int numVisibleTabs = 0;
+    for (int i = 0; i < getNumTabs(); i++) {
+        if (getTabButton(i)->isVisible())
+            numVisibleTabs++;
+    }
+    return numVisibleTabs;
+}
+
 void ButtonBar::itemDragMove(SourceDetails const& dragSourceDetails)
 {
     if (auto* tab = dynamic_cast<TabBarButtonComponent*>(dragSourceDetails.sourceComponent.get())) {
         auto ghostTabCentreOffset = ghostTab->getWidth() / 2;
-        auto targetTabPos = getWidth() / getNumTabs();
+        auto targetTabPos = getWidth() / getNumVisibleTabs();
         auto tabPos = ghostTab->getBounds().getCentreX() / targetTabPos;
 
         auto leftPos = dragSourceDetails.localPosition.getX() - ghostTabCentreOffset;
@@ -183,8 +196,8 @@ void ButtonBar::itemDragMove(SourceDetails const& dragSourceDetails)
             owner.moveTab(ghostTabIdx, tabPos);
             ghostTabIdx = tabPos;
         }
-        tab->setVisible(false);
-        getTabButton(tabPos)->setVisible(false);
+        tab->setAlpha(0.0f);
+        getTabButton(tabPos)->setAlpha(0.0f);
     }
 
 }
@@ -249,6 +262,16 @@ int TabComponent::getCurrentTabIndex()
 void TabComponent::setCurrentTabIndex(int idx)
 {
     tabs->setCurrentTabIndex(idx);
+}
+
+int TabComponent::getNumVisibleTabs()
+{
+    int numVisibleTabs = 0;
+    for (int i = 0; i < getNumTabs(); i++) {
+        if (tabs->getTabButton(i)->isVisible())
+            numVisibleTabs++;
+    }
+    return numVisibleTabs;
 }
 
 void TabComponent::clearTabs()

--- a/Source/Tabbar.h
+++ b/Source/Tabbar.h
@@ -223,6 +223,8 @@ public:
     void changeListenerCallback(ChangeBroadcaster* source) override;
 
     TabBarButton* createTabButton(String const& tabName, int tabIndex) override;
+
+    int getNumVisibleTabs();
 private:
     TabComponent& owner;
 
@@ -259,6 +261,7 @@ public:
     int getCurrentTabIndex();
     void setCurrentTabIndex(int idx);
     int getNumTabs() const noexcept                                 { return tabs->getNumTabs(); }
+    int getNumVisibleTabs();
     void removeTab(int idx);
     int getTabBarDepth() const noexcept                             { return tabDepth; };
     void changeCallback (int newCurrentTabIndex, const String& newTabName);


### PR DESCRIPTION
NOTE:
this has an issue with the tab's alpha being set (to hide the tab) and the TabButtonBar's ComponentAnimator changing that alpha. Which causes a flicker.

Unfortunately we have to use alpha to make the tab invisible (when a user drags it out etc) because the overflow menu (extra tabs menu) uses visibility status to workout what is in the menu.
