### PR TITLE
fix reset empty range parameter

### DIFF
--- a/Source/Objects/GraphOnParent.h
+++ b/Source/Objects/GraphOnParent.h
@@ -34,8 +34,8 @@ public:
         objectParameters.addParamSize(&sizeProperty);
         objectParameters.addParamBool("Is graph", cGeneral, &isGraphChild, { "No", "Yes" });
         objectParameters.addParamBool("Hide name and arguments", cGeneral, &hideNameAndArgs, { "No", "Yes" });
-        objectParameters.addParamRange("X range", cGeneral, &xRange);
-        objectParameters.addParamRange("Y range", cGeneral, &yRange);
+        objectParameters.addParamRange("X range", cGeneral, &xRange, {0, 100});
+        objectParameters.addParamRange("Y range", cGeneral, &yRange, {-1, 1});
     }
 
     void update() override

--- a/Source/Objects/ObjectParameters.h
+++ b/Source/Objects/ObjectParameters.h
@@ -48,6 +48,8 @@ public:
             if (!defaultVal.isVoid()) {
                 if (type == tColour) {
                     value->setValue(lnf.findColour(defaultVal).toString());
+                } else if (defaultVal.isArray() && defaultVal.getArray()->isEmpty()) {
+                    return;
                 } else {
                     value->setValue(defaultVal);
                 }


### PR DESCRIPTION
Fix crash on resetting empty range parameter, the range var is a `var<Array<var>>`, so we need to check if the `Array<var>` is empty

Add default range values for GOP