### PR TITLE
Fix escape key press from DnD palette & automation items

### DIFF
--- a/Source/PaletteItem.cpp
+++ b/Source/PaletteItem.cpp
@@ -249,6 +249,9 @@ void PaletteItem::resized()
 
 void PaletteItem::mouseDrag(MouseEvent const& e)
 {
+    if (isItemDragged || e.getDistanceFromDragStart() < 5)
+        return;
+
     auto dragContainer = ZoomableDragAndDropContainer::findParentDragContainerFor(this);
 
     auto scale = 2.0f;
@@ -260,7 +263,8 @@ void PaletteItem::mouseDrag(MouseEvent const& e)
     if (auto* overReorderButton = dynamic_cast<ReorderButton*>(e.originalComponent)) {
         return;
     } else {
-        paletteComp->isDnD = true;
+        setIsItemDragged(true);
+
         reorderButton->setVisible(false);
         deleteButton.setVisible(false);
 
@@ -268,7 +272,6 @@ void PaletteItem::mouseDrag(MouseEvent const& e)
         palettePatchWithOffset.add(var(dragImage.offset.getX()));
         palettePatchWithOffset.add(var(dragImage.offset.getY()));
         palettePatchWithOffset.add(var(palettePatch));
-        setIsItemDragged(true);
         dragContainer->startDragging(palettePatchWithOffset, this, ScaledImage(dragImage.image, scale), true, nullptr, nullptr, true);
     }
 }
@@ -297,7 +300,6 @@ void PaletteItem::mouseUp(MouseEvent const& e)
     if (!e.mouseWasDraggedSinceMouseDown() && e.getNumberOfClicks() >= 2) {
         nameLabel.showEditor();
     } else if (e.mouseWasDraggedSinceMouseDown()) {
-        paletteComp->isDnD = false;
         getParentComponent()->resized();
         setIsItemDragged(false);
     }

--- a/Source/Palettes.h
+++ b/Source/Palettes.h
@@ -194,7 +194,7 @@ public:
 
     void mouseDrag(MouseEvent const& e) override
     {
-        if (std::abs(e.getDistanceFromDragStart()) < 5 && !isDragging || isDnD)
+        if (std::abs(e.getDistanceFromDragStart()) < 5 && !isDragging)
             return;
 
         isDragging = true;
@@ -268,7 +268,6 @@ public:
     SafePointer<PaletteItem> draggedItem;
     Point<int> mouseDownPos;
     bool isDragging = false;
-    bool isDnD = false;
     bool isItemShowingMenu = false;
     bool isPaletteShowingMenu = false;
 

--- a/Source/Sidebar/AutomationPanel.h
+++ b/Source/Sidebar/AutomationPanel.h
@@ -280,13 +280,22 @@ public:
         reorderButton.setVisible(false);
     }
 
+    void mouseUp(MouseEvent const& e) override
+    {
+        isDragging = false;
+    }
+
     void mouseDrag(MouseEvent const& e) override
     {
-        if(e.originalComponent == &reorderButton || e.getDistanceFromDragStart() < 5) return;
-        
+        if(e.originalComponent == &reorderButton || e.getDistanceFromDragStart() < 5 || isDragging)
+            return;
+
+        isDragging = true;
+
         auto formatedParam = "#X obj 0 0 param " + param->getTitle() + ";";
 
         deleteButton.setVisible(false);
+        reorderButton.setVisible(false);
 
         auto scale = 2.0f;
         if (dragImage.image.isNull()) {
@@ -410,6 +419,8 @@ public:
     PlugDataParameter* param;
         
     std::unique_ptr<SliderParameterAttachment> attachment;
+
+    bool isDragging = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AutomationSlider)
 };


### PR DESCRIPTION
When a DnD is active, pressing escape re-spawned DnD:

https://github.com/plugdata-team/plugdata/assets/12004932/d5819f04-4c2a-4ac3-9735-be1f4b46b773


