### PR TITLE
fix activity monitor repaint bug

### DIFF
--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -405,11 +405,6 @@ void Connection::updateOverlays(int overlay)
 
 void Connection::paint(Graphics& g)
 {
-    // fix for JUCE graphics glitch: when moving objects the connection path will paint faster than the Activity overlay
-    if (showActiveState) {
-        inobj->repaint();
-        outobj->repaint();
-    }
     renderConnectionPath(g,
         cnv,
         toDrawLocalSpace,

--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -138,7 +138,7 @@ void Object::timerCallback(int timerID)
         break;
     }
     case 2: {
-        activeStateAlpha -= 0.08f;
+        activeStateAlpha -= 0.16f;
         repaint();
         if (activeStateAlpha <= 0.0f) {
             activeStateAlpha = 0.0f;
@@ -513,7 +513,7 @@ void Object::triggerOverlayActiveState()
 {
     if (showActiveState) {
         activeStateAlpha = 1.0f;
-        startTimer(2, 1000 / 30);
+        startTimer(2, 1000 / 15);
     }
 }
 

--- a/Source/Utility/StackShadow.h
+++ b/Source/Utility/StackShadow.h
@@ -711,7 +711,7 @@ public:
         if (area.getWidth() < 2 || area.getHeight() < 2)
             return;
 
-        auto fastHash = hash(String(path.getBounds().toString() + String(radius) + String(offset.x) + String(offset.y) + String(spread) + String(scale)));
+        auto fastHash = hash(String(path.getBounds().toString() + String(radius) + String(offset.x) + String(offset.y) + String(spread)));
 
         Image renderedPath = dropShadowCache.getFromHashCode(fastHash);
         if (renderedPath.isNull()) {


### PR DESCRIPTION
remove mitigation for juce painting bug (didn't work correctly anyway) don't use scale for hash in stackshadow (it's not used anyway ATM)