### PR TITLE
fix message activity glow not repainting correctly

### DIFF
--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -511,10 +511,18 @@ void Object::paintOverChildren(Graphics& g)
 
 void Object::triggerOverlayActiveState()
 {
-    if (showActiveState) {
-        activeStateAlpha = 1.0f;
-        startTimer(2, 1000 / 15);
-    }
+    if (!showActiveState && rateReducer.tooFast())
+        return;
+
+    activeStateAlpha = 1.0f;
+    startTimer(2, 1000 / ACTIVITY_UPDATE_RATE);
+
+    // Because the timer is being reset when new messages come in
+    // it will not trigger it's callback until it's free-running
+    // so we manually call the repaint here if this happens
+    MessageManager::callAsync([this](){
+        repaint();
+    });
 }
 
 void Object::paint(Graphics& g)

--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -511,7 +511,10 @@ void Object::paintOverChildren(Graphics& g)
 
 void Object::triggerOverlayActiveState()
 {
-    if (!showActiveState && rateReducer.tooFast())
+    if (!showActiveState)
+        return;
+
+    if (rateReducer.tooFast())
         return;
 
     activeStateAlpha = 1.0f;
@@ -527,7 +530,7 @@ void Object::triggerOverlayActiveState()
 
 void Object::paint(Graphics& g)
 {
-    if ((showActiveState && isTimerRunning(2))) {
+    if ((showActiveState || isTimerRunning(2))) {
         g.setOpacity(activeStateAlpha);
         // show activation state glow
         g.drawImage(activityOverlayImage, getLocalBounds().toFloat());

--- a/Source/Object.h
+++ b/Source/Object.h
@@ -9,7 +9,9 @@
 #include "Utility/ModifierKeyListener.h"
 #include <JuceHeader.h>
 #include "Utility/SettingsFile.h"
+#include "Utility/RateReducer.h"
 
+#define ACTIVITY_UPDATE_RATE 15
 
 class ObjectBase;
 class Iolet;
@@ -138,6 +140,8 @@ private:
     Image activityOverlayImage;
 
     ObjectDragState& ds;
+
+    RateReducer rateReducer = RateReducer(ACTIVITY_UPDATE_RATE);
 
     std::unique_ptr<TextEditor> newObjectEditor;
 


### PR DESCRIPTION
* we use a ratereducer to reduce the speed at which the activity is triggered and also trigger a repaint when the message first comes in this is because the messages can be so fast the timer is constantly reset
* this fixes all grahphics glitches that I have found, and also allows us to run the activity indicator at a lower rate 15hz in this PR