### PR TITLE
force the ptr to be registered with the message listener when first constructed

### DIFF
--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -76,7 +76,7 @@ Connection::Connection(Canvas* parent, Iolet* s, Iolet* e, void* oc)
 
     updateOverlays(cnv->getOverlays());
 
-    setPointer(ptr.getRaw<void>());
+    setPointer(ptr.getRaw<void>(), true);
 }
 
 Connection::~Connection()
@@ -177,12 +177,12 @@ void Connection::popPathState()
     updatePath();
 }
 
-void Connection::setPointer(void* newPtr)
+void Connection::setPointer(void* newPtr, bool forceUpdate)
 {
     auto originalPointer = ptr.getRawUnchecked<t_outconnect>();
-    if(originalPointer != newPtr) {
+    if(forceUpdate || originalPointer != newPtr) {
         ptr = pd::WeakReference(newPtr, cnv->pd);
-        
+
         cnv->pd->unregisterMessageListener(originalPointer, this);
         cnv->pd->registerMessageListener(newPtr, this);
     }

--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -88,7 +88,7 @@ public:
     bool intersects(Rectangle<float> toCheck, int accuracy = 4) const;
     int getClosestLineIdx(Point<float> const& position, PathPlan const& plan);
 
-    void setPointer(void* ptr);
+    void setPointer(void* ptr, bool forceUpdate = false);
     void* getPointer();
 
     t_symbol* getPathState();


### PR DESCRIPTION
connection was not registering the listener:

![Screenshot from 2023-08-28 15-42-22](https://github.com/plugdata-team/plugdata/assets/12004932/47d51cd6-a78e-41e4-850f-cb5ddf769290)

with the fix:

![Screenshot from 2023-08-28 16-00-19](https://github.com/plugdata-team/plugdata/assets/12004932/843bdf8a-d8b1-414d-96d6-25821baac819)

