### PR TITLE
Prevent clap from crashing when exiting plugin-mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set (CMAKE_CXX_STANDARD 20)
 # Sfizz doesn't want to compile on aarch64 linux here...
 if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
   set(ENABLE_SFIZZ OFF)
-else()
+endif()
 
 function(message)
     if (NOT MESSAGE_QUIET)

--- a/Source/PluginMode.h
+++ b/Source/PluginMode.h
@@ -129,7 +129,6 @@ public:
                                       bounds = windowBounds]() {
             editor->setConstrainer(editor->defaultConstrainer);
             editor->setBoundsConstrained(bounds);
-            editor->getParentComponent()->resized();
             if (auto* tabbar = editor->getActiveTabbar()) {
                 tabbar->resized();
             }


### PR DESCRIPTION
and general compilation fix

addresses #1158