### PR TITLE
start work on DnD from Object Browser 

### DIFF
--- a/Source/Dialogs/ListBoxObjectItem.cpp
+++ b/Source/Dialogs/ListBoxObjectItem.cpp
@@ -2,7 +2,7 @@
 #include "ListBoxObjectItem.h"
 #include "ObjectBrowserDialog.h"
 
-ListBoxObjectItem::ListBoxObjectItem(ObjectsListBox* parent, int rowNumber, bool isSelected, std::function<void()> dismissDialog)
+ListBoxObjectItem::ListBoxObjectItem(ObjectsListBox* parent, int rowNumber, bool isSelected, std::function<void(bool shouldFade)> dismissDialog)
     : row(rowNumber)
     , rowIsSelected(isSelected)
     , objectsListBox(parent)
@@ -56,6 +56,11 @@ void ListBoxObjectItem::mouseDown(MouseEvent const& e)
     objectsListBox->selectRow(row, true, true);
 }
 
+void ListBoxObjectItem::mouseUp(MouseEvent const& e)
+{
+    dismissMenu(false);
+}
+
 void ListBoxObjectItem::mouseDrag(MouseEvent const& e)
 {
     if (e.getDistanceFromDragStart() < 5)
@@ -76,7 +81,7 @@ void ListBoxObjectItem::mouseDrag(MouseEvent const& e)
         dragImage = offlineObjectRenderer->patchToTempImage(formatedObject, scale);
     }
 
-    dismissMenu();
+    dismissMenu(true);
 
     Array<var> palettePatchWithOffset;
     palettePatchWithOffset.add(var(dragImage.offset.getX()));

--- a/Source/Dialogs/ListBoxObjectItem.cpp
+++ b/Source/Dialogs/ListBoxObjectItem.cpp
@@ -58,13 +58,16 @@ void ListBoxObjectItem::mouseDown(MouseEvent const& e)
 
 void ListBoxObjectItem::mouseUp(MouseEvent const& e)
 {
-    dismissMenu(false);
+    if (dragging)
+        dismissMenu(false);
 }
 
 void ListBoxObjectItem::mouseDrag(MouseEvent const& e)
 {
     if (e.getDistanceFromDragStart() < 5)
         return;
+
+    dragging = true;
 
     auto* dragContainer = ZoomableDragAndDropContainer::findParentDragContainerFor(this);
 

--- a/Source/Dialogs/ListBoxObjectItem.cpp
+++ b/Source/Dialogs/ListBoxObjectItem.cpp
@@ -1,0 +1,100 @@
+#include <JuceHeader.h>
+#include "ListBoxObjectItem.h"
+#include "ObjectBrowserDialog.h"
+
+ListBoxObjectItem::ListBoxObjectItem(ObjectsListBox* parent, int rowNumber, bool isSelected, std::function<void()> dismissDialog)
+    : row(rowNumber)
+    , rowIsSelected(isSelected)
+    , objectsListBox(parent)
+    , dismissMenu(dismissDialog)
+{
+    objectName = parent->objects[rowNumber];
+    objectDescription = parent->descriptions[objectName];
+}
+
+void ListBoxObjectItem::paint(juce::Graphics& g)
+{
+    if (rowIsSelected || mouseHover) {
+        auto colour = findColour(PlugDataColour::panelActiveBackgroundColourId);
+        if (mouseHover && !rowIsSelected)
+            colour = colour.withAlpha(0.5f);
+
+        g.setColour(colour);
+        g.fillRoundedRectangle(getLocalBounds().reduced(4, 2).toFloat(), Corners::defaultCornerRadius);
+        //g.fillRoundedRectangle({ 4.0f, 1.0f, getWidth() - 8.0f, getHeight() - 2.0f }, Corners::defaultCornerRadius);
+    }
+
+    auto colour = rowIsSelected ? findColour(PlugDataColour::panelActiveTextColourId) : findColour(PlugDataColour::panelTextColourId);
+
+    auto textBounds = Rectangle<int>(0, 0, getWidth(), getHeight()).reduced(18, 6);
+
+    Fonts::drawStyledText(g, objectName, textBounds.removeFromTop(textBounds.proportionOfHeight(0.5f)), colour, Bold, 14);
+
+    Fonts::drawText(g, objectDescription, textBounds, colour, 14);
+}
+
+bool ListBoxObjectItem::hitTest(int x, int y)
+{
+    auto bounds = getLocalBounds().reduced(4, 2);
+    return bounds.contains(x, y);
+}
+
+void ListBoxObjectItem::mouseEnter(MouseEvent const& e)
+{
+    mouseHover = true;
+    repaint();
+}
+
+void ListBoxObjectItem::mouseExit(MouseEvent const& e)
+{
+    mouseHover = false;
+    repaint();
+}
+
+void ListBoxObjectItem::mouseDown(MouseEvent const& e)
+{
+    objectsListBox->selectRow(row, true, true);
+}
+
+void ListBoxObjectItem::mouseDrag(MouseEvent const& e)
+{
+    if (e.getDistanceFromDragStart() < 5)
+        return;
+
+    auto* dragContainer = ZoomableDragAndDropContainer::findParentDragContainerFor(this);
+
+    if (dragContainer->isDragAndDropActive())
+        return;
+
+    // auto patchWithTheme = substituteThemeColours(objectPatch);
+
+    auto formatedObject = "#X obj 0 0 " + objectName;
+
+    auto scale = 2.0f;
+    if (dragImage.image.isNull()) {
+        auto offlineObjectRenderer = OfflineObjectRenderer::findParentOfflineObjectRendererFor(this);
+        dragImage = offlineObjectRenderer->patchToTempImage(formatedObject, scale);
+    }
+
+    dismissMenu();
+
+    Array<var> palettePatchWithOffset;
+    palettePatchWithOffset.add(var(dragImage.offset.getX()));
+    palettePatchWithOffset.add(var(dragImage.offset.getY()));
+    palettePatchWithOffset.add(var(formatedObject));
+    dragContainer->startDragging(palettePatchWithOffset, this, ScaledImage(dragImage.image, scale), true, nullptr, nullptr, true);
+}
+
+String ListBoxObjectItem::getItemName() const
+{
+    return objectName;
+}
+
+void ListBoxObjectItem::refresh(String name, String description, int rowNumber, bool isSelected)
+{
+    objectName = name;
+    objectDescription = description;
+    row = rowNumber;
+    rowIsSelected = isSelected;
+    repaint();
+}

--- a/Source/Dialogs/ListBoxObjectItem.cpp
+++ b/Source/Dialogs/ListBoxObjectItem.cpp
@@ -58,39 +58,18 @@ void ListBoxObjectItem::mouseDown(MouseEvent const& e)
 
 void ListBoxObjectItem::mouseUp(MouseEvent const& e)
 {
-    if (dragging)
+    if (e.mouseWasDraggedSinceMouseDown())
         dismissMenu(false);
 }
 
-void ListBoxObjectItem::mouseDrag(MouseEvent const& e)
+void ListBoxObjectItem::dismiss(bool withAnimation)
 {
-    if (e.getDistanceFromDragStart() < 5)
-        return;
+    dismissMenu(withAnimation);
+}
 
-    dragging = true;
-
-    auto* dragContainer = ZoomableDragAndDropContainer::findParentDragContainerFor(this);
-
-    if (dragContainer->isDragAndDropActive())
-        return;
-
-    // auto patchWithTheme = substituteThemeColours(objectPatch);
-
-    auto formatedObject = "#X obj 0 0 " + objectName;
-
-    auto scale = 2.0f;
-    if (dragImage.image.isNull()) {
-        auto offlineObjectRenderer = OfflineObjectRenderer::findParentOfflineObjectRendererFor(this);
-        dragImage = offlineObjectRenderer->patchToTempImage(formatedObject, scale);
-    }
-
-    dismissMenu(true);
-
-    Array<var> palettePatchWithOffset;
-    palettePatchWithOffset.add(var(dragImage.offset.getX()));
-    palettePatchWithOffset.add(var(dragImage.offset.getY()));
-    palettePatchWithOffset.add(var(formatedObject));
-    dragContainer->startDragging(palettePatchWithOffset, this, ScaledImage(dragImage.image, scale), true, nullptr, nullptr, true);
+String ListBoxObjectItem::getObjectString()
+{
+    return "#X obj 0 0 " + objectName;
 }
 
 String ListBoxObjectItem::getItemName() const

--- a/Source/Dialogs/ListBoxObjectItem.h
+++ b/Source/Dialogs/ListBoxObjectItem.h
@@ -32,5 +32,7 @@ private:
     ImageWithOffset dragImage;
     bool mouseHover = false;
 
+    bool dragging = false;
+
     std::function<void(bool shouldFade)> dismissMenu;
 };

--- a/Source/Dialogs/ListBoxObjectItem.h
+++ b/Source/Dialogs/ListBoxObjectItem.h
@@ -1,19 +1,19 @@
 #pragma once
 
-//#include <JuceHeader.h>
 #include "../Utility/OfflineObjectRenderer.h"
 
 class ObjectsListBox;
 class ListBoxObjectItem : public juce::Component
 {
 public:
-    ListBoxObjectItem(ObjectsListBox* parent, int rowNumber, bool isSelected, std::function<void()> dismissDialog);
+    ListBoxObjectItem(ObjectsListBox* parent, int rowNumber, bool isSelected, std::function<void(bool shouldFade)> dismissDialog);
 
     void paint(juce::Graphics& g) override;
 
     bool hitTest(int x, int y);
 
     void mouseDown(MouseEvent const& e) override;
+    void mouseUp(MouseEvent const& e) override;
     void mouseEnter(MouseEvent const& e) override;
     void mouseExit(MouseEvent const& e) override;
     void mouseDrag(MouseEvent const& e) override;
@@ -32,5 +32,5 @@ private:
     ImageWithOffset dragImage;
     bool mouseHover = false;
 
-    std::function<void()> dismissMenu;
+    std::function<void(bool shouldFade)> dismissMenu;
 };

--- a/Source/Dialogs/ListBoxObjectItem.h
+++ b/Source/Dialogs/ListBoxObjectItem.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "../Utility/OfflineObjectRenderer.h"
+#include "../Utility/ObjectDragAndDrop.h"
 
 class ObjectsListBox;
-class ListBoxObjectItem : public juce::Component
+class ListBoxObjectItem : public ObjectDragAndDrop
 {
 public:
     ListBoxObjectItem(ObjectsListBox* parent, int rowNumber, bool isSelected, std::function<void(bool shouldFade)> dismissDialog);
@@ -16,9 +16,11 @@ public:
     void mouseUp(MouseEvent const& e) override;
     void mouseEnter(MouseEvent const& e) override;
     void mouseExit(MouseEvent const& e) override;
-    void mouseDrag(MouseEvent const& e) override;
 
     String getItemName() const;
+
+    String getObjectString() override;
+    void dismiss(bool withAnimation) override;
 
     void refresh(String objectName, String objectDescription, int rowNumber, bool isSelected);
 
@@ -29,10 +31,7 @@ private:
     bool rowIsSelected = false;
     ObjectsListBox* objectsListBox;
 
-    ImageWithOffset dragImage;
     bool mouseHover = false;
-
-    bool dragging = false;
 
     std::function<void(bool shouldFade)> dismissMenu;
 };

--- a/Source/Dialogs/ListBoxObjectItem.h
+++ b/Source/Dialogs/ListBoxObjectItem.h
@@ -1,0 +1,36 @@
+#pragma once
+
+//#include <JuceHeader.h>
+#include "../Utility/OfflineObjectRenderer.h"
+
+class ObjectsListBox;
+class ListBoxObjectItem : public juce::Component
+{
+public:
+    ListBoxObjectItem(ObjectsListBox* parent, int rowNumber, bool isSelected, std::function<void()> dismissDialog);
+
+    void paint(juce::Graphics& g) override;
+
+    bool hitTest(int x, int y);
+
+    void mouseDown(MouseEvent const& e) override;
+    void mouseEnter(MouseEvent const& e) override;
+    void mouseExit(MouseEvent const& e) override;
+    void mouseDrag(MouseEvent const& e) override;
+
+    String getItemName() const;
+
+    void refresh(String objectName, String objectDescription, int rowNumber, bool isSelected);
+
+private:
+    int row;
+    String objectName;
+    String objectDescription;
+    bool rowIsSelected = false;
+    ObjectsListBox* objectsListBox;
+
+    ImageWithOffset dragImage;
+    bool mouseHover = false;
+
+    std::function<void()> dismissMenu;
+};

--- a/Source/Dialogs/ObjectBrowserDialog.h
+++ b/Source/Dialogs/ObjectBrowserDialog.h
@@ -100,8 +100,6 @@ public:
 
     int getNumRows() override
     {
-        auto size = objects.size();
-        std::cout << "num rows: " << size << std::endl;
         return objects.size();
     }
 

--- a/Source/Dialogs/ObjectReferenceDialog.h
+++ b/Source/Dialogs/ObjectReferenceDialog.h
@@ -5,6 +5,11 @@
  // WARRANTIES, see the file, "LICENSE.txt," in this distribution.
  */
 
+#include <JuceHeader.h>
+#include "../LookAndFeel.h"
+#include "../PluginEditor.h"
+#include "../PluginProcessor.h"
+
 class ObjectInfoPanel : public Component {
     struct CategoryPanel : public Component {
         CategoryPanel(String const& name, Array<std::pair<String, String>> const& content)

--- a/Source/PaletteItem.cpp
+++ b/Source/PaletteItem.cpp
@@ -1,8 +1,6 @@
 #include "PaletteItem.h"
 #include "Palettes.h"
 #include "Constants.h"
-#include "Utility/ZoomableDragAndDropContainer.h"
-#include "Utility/OfflineObjectRenderer.h"
 #include "Utility/StackShadow.h"
 
 PaletteItem::PaletteItem(PluginEditor* e, PaletteDraggableList* parent, ValueTree tree)
@@ -220,10 +218,12 @@ void PaletteItem::paint(Graphics& g)
     }
 }
 
-void PaletteItem::lookAndFeelChanged()
+void PaletteItem::mouseDown(MouseEvent const& e)
 {
-    // reset the image to null so the next drag will change the colour
-    dragImage.image = Image();
+    if (reorderButton.get() == e.originalComponent)
+        setIsReordering(true);
+    else
+        setIsReordering(false);
 }
 
 void PaletteItem::mouseEnter(MouseEvent const& e)
@@ -246,33 +246,9 @@ void PaletteItem::resized()
     deleteButton.setCentrePosition(getLocalBounds().getRight() - 30, componentCentre);
 }
 
-void PaletteItem::mouseDrag(MouseEvent const& e)
+String PaletteItem::getObjectString()
 {
-    if (isItemDragged || e.getDistanceFromDragStart() < 5)
-        return;
-
-    auto dragContainer = ZoomableDragAndDropContainer::findParentDragContainerFor(this);
-
-    auto scale = 2.0f;
-    if (dragImage.image.isNull()) {
-        auto offlineObjectRenderer = editor->offlineRenderer;
-        dragImage = offlineObjectRenderer.patchToTempImage(palettePatch, scale);
-    }
-
-    if (auto* overReorderButton = dynamic_cast<ReorderButton*>(e.originalComponent)) {
-        return;
-    } else {
-        setIsItemDragged(true);
-
-        reorderButton->setVisible(false);
-        deleteButton.setVisible(false);
-
-        Array<var> palettePatchWithOffset;
-        palettePatchWithOffset.add(var(dragImage.offset.getX()));
-        palettePatchWithOffset.add(var(dragImage.offset.getY()));
-        palettePatchWithOffset.add(var(palettePatch));
-        dragContainer->startDragging(palettePatchWithOffset, this, ScaledImage(dragImage.image, scale), true, nullptr, nullptr, true);
-    }
+    return palettePatch;
 }
 
 void PaletteItem::deleteItem()

--- a/Source/PaletteItem.h
+++ b/Source/PaletteItem.h
@@ -3,12 +3,12 @@
 #include <JuceHeader.h>
 
 #include "Pd/Instance.h"
-#include "Utility/OfflineObjectRenderer.h"
+#include "Utility/ObjectDragAndDrop.h"
 
 class PluginEditor;
 class PaletteDraggableList;
 class ReorderButton;
-class PaletteItem : public Component {
+class PaletteItem : public ObjectDragAndDrop {
 public:
     PaletteItem(PluginEditor* e, PaletteDraggableList* parent, ValueTree tree);
     ~PaletteItem();
@@ -16,10 +16,12 @@ public:
     void paint(Graphics& g) override;
     void resized() override;
 
-    void mouseDrag(MouseEvent const& e) override;
+    void mouseDown(MouseEvent const& e) override;
     void mouseUp(MouseEvent const& e) override;
     void mouseEnter(MouseEvent const& e) override;
     void mouseExit(MouseEvent const& e) override;
+
+    String getObjectString() override;
 
     bool hitTest(int x, int y) override;
 
@@ -27,11 +29,7 @@ public:
 
     bool isSubpatchOrAbstraction(String const& patchAsString);
 
-    void lookAndFeelChanged() override;
-
     Image patchToTempImage(String const& patch);
-
-    ImageWithOffset dragImage;
 
     std::pair<std::vector<bool>, std::vector<bool>> countIolets(String const& patchAsString);
 

--- a/Source/ResizableTabbedComponent.cpp
+++ b/Source/ResizableTabbedComponent.cpp
@@ -9,12 +9,14 @@
 #include "SplitViewResizer.h"
 #include "PluginProcessor.h"
 #include "Dialogs/AddObjectMenu.h"
+#include "Dialogs/ListBoxObjectItem.h"
 #include "PaletteItem.h"
 #include "Palettes.h"
 #include "Sidebar/DocumentBrowser.h"
 #include "Sidebar/AutomationPanel.h"
 #include "Tabbar.h"
 #include "TabBarButtonComponent.h"
+
 
 #define ENABLE_SPLITS_DROPZONE_DEBUGGING 0
 
@@ -44,7 +46,8 @@ bool ResizableTabbedComponent::isInterestedInDragSource(SourceDetails const& dra
     auto objectItem = dynamic_cast<ObjectItem*>(dragSourceDetails.sourceComponent.get());
     auto docBrowserItem = dynamic_cast<DocumentBrowserViewBase*>(dragSourceDetails.sourceComponent.get());
     auto automationSlider = dynamic_cast<AutomationSlider*>(dragSourceDetails.sourceComponent.get());
-    if (windowTab || paletteItem || docBrowserItem || automationSlider || objectItem)
+    auto objectBrowser = dynamic_cast<ListBoxObjectItem*>(dragSourceDetails.sourceComponent.get());
+    if (windowTab || paletteItem || docBrowserItem || automationSlider || objectItem || objectBrowser)
         return true;
     return false;
 }
@@ -79,7 +82,10 @@ void ResizableTabbedComponent::itemDropped(SourceDetails const& dragSourceDetail
             moveTabToNewSplit(dragSourceDetails);
             break;
         }
-    } else if (dynamic_cast<PaletteItem*>(dragSourceDetails.sourceComponent.get()) || dynamic_cast<AutomationSlider*>(dragSourceDetails.sourceComponent.get()) || dynamic_cast<ObjectItem*>(dragSourceDetails.sourceComponent.get())) {
+    } else if (dynamic_cast<PaletteItem*>(dragSourceDetails.sourceComponent.get()) ||
+               dynamic_cast<AutomationSlider*>(dragSourceDetails.sourceComponent.get()) ||
+               dynamic_cast<ObjectItem*>(dragSourceDetails.sourceComponent.get()) ||
+               dynamic_cast<ListBoxObjectItem*>(dragSourceDetails.sourceComponent.get())){
         if (!tabComponent)
             return;
 
@@ -398,7 +404,8 @@ void ResizableTabbedComponent::itemDragMove(SourceDetails const& dragSourceDetai
     auto palette = dynamic_cast<PaletteItem*>(dragSourceDetails.sourceComponent.get());
     auto automationSlider = dynamic_cast<AutomationSlider*>(dragSourceDetails.sourceComponent.get());
     auto objectItem = dynamic_cast<ObjectItem*>(dragSourceDetails.sourceComponent.get());
-    if (palette || automationSlider || objectItem) {
+    auto objectBrowser = dynamic_cast<ListBoxObjectItem*>(dragSourceDetails.sourceComponent.get());
+    if (palette || automationSlider || objectItem || objectBrowser) {
         isDragAndDropOver = false;
         editor->splitView.setFocus(this);
     }

--- a/Source/ResizableTabbedComponent.cpp
+++ b/Source/ResizableTabbedComponent.cpp
@@ -40,8 +40,10 @@ ResizableTabbedComponent::~ResizableTabbedComponent()
 bool ResizableTabbedComponent::isInterestedInDragSource(SourceDetails const& dragSourceDetails)
 {
     auto windowTab = dynamic_cast<TabBarButtonComponent*>(dragSourceDetails.sourceComponent.get());
-    auto docBrowserItem = dynamic_cast<DocumentBrowserViewBase*>(dragSourceDetails.sourceComponent.get());
     auto draggedObject = dynamic_cast<ObjectDragAndDrop*>(dragSourceDetails.sourceComponent.get());
+
+    // TODO: not implemented yet
+    auto docBrowserItem = dynamic_cast<DocumentBrowserViewBase*>(dragSourceDetails.sourceComponent.get());
 
     if (windowTab || docBrowserItem || draggedObject)
         return true;

--- a/Source/Sidebar/AutomationPanel.h
+++ b/Source/Sidebar/AutomationPanel.h
@@ -160,6 +160,10 @@ public:
             lastName = nameLabel.getText(false);
         };
 
+        nameLabel.onTextChange = [this]() {
+            resetDragAndDropImage();
+        };
+
         nameLabel.onEditorHide = [this]() {
             StringArray allNames;
             for (auto* param : pd->getParameters()) {

--- a/Source/Utility/ObjectDragAndDrop.h
+++ b/Source/Utility/ObjectDragAndDrop.h
@@ -15,6 +15,11 @@ public:
 
     void lookAndFeelChanged() override
     {
+        resetDragAndDropImage();
+    }
+
+    void resetDragAndDropImage()
+    {
         dragImage.image = Image();
     }
 

--- a/Source/Utility/ObjectDragAndDrop.h
+++ b/Source/Utility/ObjectDragAndDrop.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include "ZoomableDragAndDropContainer.h"
+#include "OfflineObjectRenderer.h"
+
+class ObjectDragAndDrop : public Component
+{
+public:
+    ObjectDragAndDrop(){};
+
+    virtual String getObjectString() = 0;
+
+    virtual void dismiss(bool withAnimation){};
+
+    void lookAndFeelChanged() override
+    {
+        dragImage.image = Image();
+    }
+
+    void setIsReordering(bool isReordering)
+    {
+        reordering = isReordering;
+    }
+
+    void mouseDrag(MouseEvent const& e) override final
+    {
+        if (reordering || e.getDistanceFromDragStart() < 5)
+            return;
+
+        auto* dragContainer = ZoomableDragAndDropContainer::findParentDragContainerFor(this);
+
+        if (dragContainer->isDragAndDropActive())
+            return;
+
+        auto scale = 2.0f;
+        if (dragImage.image.isNull()) {
+            auto offlineObjectRenderer = OfflineObjectRenderer::findParentOfflineObjectRendererFor(this);
+            dragImage = offlineObjectRenderer->patchToTempImage(getObjectString(), scale);
+        }
+
+        dismiss(true);
+
+        Array<var> palettePatchWithOffset;
+        palettePatchWithOffset.add(var(dragImage.offset.getX()));
+        palettePatchWithOffset.add(var(dragImage.offset.getY()));
+        palettePatchWithOffset.add(var(getObjectString()));
+        dragContainer->startDragging(palettePatchWithOffset, this, ScaledImage(dragImage.image, scale), true, nullptr, nullptr, true);
+    }
+
+private:
+    bool reordering = false;
+    ImageWithOffset dragImage;
+};

--- a/Source/Utility/StackShadow.h
+++ b/Source/Utility/StackShadow.h
@@ -16,6 +16,7 @@
 
 #include <JuceHeader.h>
 #include "Utility/HashUtils.h"
+#include "Utility/Config.h"
 
 #if JUCE_WINDOWS
 // Enable for JUCE >=7.0.6

--- a/Source/Utility/ZoomableDragAndDropContainer.cpp
+++ b/Source/Utility/ZoomableDragAndDropContainer.cpp
@@ -39,6 +39,8 @@
 
 #include "../Dialogs/AddObjectMenu.h"
 
+#include "../Dialogs/ListBoxObjectItem.h"
+
 bool juce_performDragDropFiles(StringArray const&, bool const copyFiles, bool& shouldStop);
 bool juce_performDragDropText(String const&, bool& shouldStop);
 
@@ -62,7 +64,7 @@ public:
         , originalInputSourceType(draggingSource->getType())
         , isZoomable(canZoom)
     {
-        if (auto addObjectItem = dynamic_cast<ObjectItem*>(sourceComponent))
+        if (dynamic_cast<ObjectItem*>(sourceComponent) || dynamic_cast<ListBoxObjectItem*>(sourceComponent))
             isObjectItem = true;
 
         zoomImageComponent.setImage(im.getImage());

--- a/Source/Utility/ZoomableDragAndDropContainer.cpp
+++ b/Source/Utility/ZoomableDragAndDropContainer.cpp
@@ -138,6 +138,8 @@ public:
         if (e.originalComponent != this && isOriginalInputSource(e.source)) {
             if (rateReducer.tooFast())
                 return;
+
+            beginDragAutoRepeat(16);
             currentScreenPos = e.getScreenPosition();
             updateLocation(true, currentScreenPos);
             Component* target = nullptr;

--- a/Source/Utility/ZoomableDragAndDropContainer.cpp
+++ b/Source/Utility/ZoomableDragAndDropContainer.cpp
@@ -37,9 +37,8 @@
 // if we are inside the splitview, don't reset the scale of the dragged image, regardless of what we are over
 #include "../SplitView.h"
 
-#include "../Dialogs/AddObjectMenu.h"
-
-#include "../Dialogs/ListBoxObjectItem.h"
+// objects are only drag and dropped onto a canvas, so we dynamic cast straight away to see if the dragged object is from an object
+#include "ObjectDragAndDrop.h"
 
 bool juce_performDragDropFiles(StringArray const&, bool const copyFiles, bool& shouldStop);
 bool juce_performDragDropText(String const&, bool& shouldStop);
@@ -64,7 +63,7 @@ public:
         , originalInputSourceType(draggingSource->getType())
         , isZoomable(canZoom)
     {
-        if (dynamic_cast<ObjectItem*>(sourceComponent) || dynamic_cast<ListBoxObjectItem*>(sourceComponent))
+        if (dynamic_cast<ObjectDragAndDrop*>(sourceComponent))
             isObjectItem = true;
 
         zoomImageComponent.setImage(im.getImage());


### PR DESCRIPTION
* pin for this also? - or if object menu is pinned we also pin this?
* Text that clearly says: "Drag to canvas"?

* Search results still need to have this DnD system, but should be just as simple now to implement.
* :warning:  we need to deal with UI objects like we do in addobjectmenu. So we should probalby make that part of the patch class. ( otherwise UI objects don't get correct colours)