### PR TITLE
fix [hack] for crash when dragging a tab to the right edge of a tabbar from another tabbar.

### DIFF
--- a/Source/Tabbar.cpp
+++ b/Source/Tabbar.cpp
@@ -188,7 +188,7 @@ void ButtonBar::itemDragEnter(SourceDetails const& dragSourceDetails)
             // FIXME: This is a hack. When tab is added to tabbar right edge, and it goes into overflow
             //        we don't know when that will happen.
             //        So we force the right most tab to think it's always one less.
-            auto tabPos = jmin(dragSourceDetails.localPosition.getX() / targetTabPos, getNumVisibleTabs() - 1);
+            auto tabPos = jmin(dragSourceDetails.localPosition.getX() / targetTabPos, getNumVisibleTabs() - 2);
             inOtherSplit = true;
             auto unusedComponent = std::make_unique<Component>();
             owner.addTab(tab->getButtonText(), unusedComponent.get(), tabPos);

--- a/Source/Tabbar.cpp
+++ b/Source/Tabbar.cpp
@@ -25,8 +25,12 @@ public:
     void setTabButtonToGhost(TabBarButton* tabButton)
     {
         tab = tabButton;
-        setBounds(tab->getBounds());
-        repaint();
+        // this should never happen, if it does then the index for the tab is wrong ( getTab(idx) will return nullptr )
+        // which can happen if the tabbar goes into overflow, because we don't know exactly when that will happen
+        if (tab){
+            setBounds(tab->getBounds());
+            repaint();
+        }
     }
 
     int getIndex()
@@ -181,10 +185,14 @@ void ButtonBar::itemDragEnter(SourceDetails const& dragSourceDetails)
             // WARNING: because we are using the overflow (show extra items menu)
             // we need to find out how many tabs are visible, not how many there are all together
             auto targetTabPos = getWidth() / (getNumVisibleTabs() + 1);
-            auto tabPos = dragSourceDetails.localPosition.getX() / targetTabPos;
+            // FIXME: This is a hack. When tab is added to tabbar right edge, and it goes into overflow
+            //        we don't know when that will happen.
+            //        So we force the right most tab to think it's always one less.
+            auto tabPos = jmin(dragSourceDetails.localPosition.getX() / targetTabPos, getNumVisibleTabs() - 1);
             inOtherSplit = true;
             auto unusedComponent = std::make_unique<Component>();
             owner.addTab(tab->getButtonText(), unusedComponent.get(), tabPos);
+
             auto* fakeTab = getTabButton(tabPos);
             tab->getProperties().set("dragged", var(true));
             ghostTab->setTabButtonToGhost(fakeTab);


### PR DESCRIPTION
We need to have our own TabButtonBar, that is able to work correctly with DnD & Overflow

This fix forces all tabs dragged into the right edge of a tabbar to be added before the last. Which stops the index being incorrect if the the tabbar goes into overflow, with the caveat that it may not look correct when tabs move with animating.