### PR TITLE
[comment] don't use formatted text in GUI

### DIFF
--- a/Source/Objects/CommentObject.h
+++ b/Source/Objects/CommentObject.h
@@ -26,7 +26,7 @@ public:
 
     void update() override
     {
-        objectText = getText().trimEnd();
+        objectText = objectText.trimEnd();
 
         if (auto obj = ptr.get<t_text>()) {
             sizeProperty = TextObjectHelper::getWidthInChars(obj.get());


### PR DESCRIPTION
Rather than using the atom list when painting the string, just use objectText, which has already been fixed up by setSymbol().

can iterate on this more if getText() should reflect this, or if tests are helpful, etc.

Fixes #1185