### PR TITLE
various canvas fixes

### DIFF
--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -504,7 +504,7 @@ StringArray Connection::getMessageFormated()
         formatedMessage.add("symbol:");
         formatedMessage.add(String(args[0].getSymbol()));
     } else if (name == "list") {
-        formatedMessage.add("list:");
+        formatedMessage.add("list (" + String(args.size()) + "):");
         for (auto& arg : args) {
             if (arg.isFloat()) {
                 formatedMessage.add(String(arg.getFloat()));

--- a/Source/Dialogs/ConnectionMessageDisplay.h
+++ b/Source/Dialogs/ConnectionMessageDisplay.h
@@ -76,7 +76,7 @@ private:
 
         auto halfEditorWidth = getParentComponent()->getWidth() / 2;
         auto fontStyle = haveMessage ? FontStyle::Semibold : FontStyle::Regular;
-        auto textFont = Font(haveMessage ? Fonts::getSemiBoldFont() : Fonts::getCurrentFont());
+        auto textFont = Font(haveMessage ? Fonts::getSemiBoldFont() : Fonts::getDefaultFont());
         textFont.setSizeAndStyle(14, FontStyle::Regular, 1.0f, 0.0f);
 
         int stringWidth;
@@ -103,10 +103,10 @@ private:
 
             messageItemsWithFormat.add(TextStringWithMetrics(stringItem, fontStyle, stringWidth));
 
-            if (fontStyle != FontStyle::Monospace) {
-                // set up font for next item/s - use monospace for values / lists etc
-                fontStyle = FontStyle::Monospace;
-                textFont = Font(Fonts::getMonospaceFont());
+            if (fontStyle != FontStyle::Regular) {
+                // set up font for next item/s -regular font to support extended character
+                fontStyle = FontStyle::Regular;
+                textFont = Font(Fonts::getDefaultFont());
             }
         }
 

--- a/Source/Object.h
+++ b/Source/Object.h
@@ -132,6 +132,8 @@ private:
     bool showActiveState = false;
     float activeStateAlpha = 0.0f;
 
+    bool isObjectMouseActive = false;
+
     Image activityOverlayImage;
 
     ObjectDragState& ds;

--- a/Source/Objects/IEMHelper.h
+++ b/Source/Objects/IEMHelper.h
@@ -279,27 +279,28 @@ public:
 
     void updateLabel(std::unique_ptr<ObjectLabel>& label)
     {
-        int fontHeight = getFontHeight();
-
-        const String text = getExpandedLabelText();
+        const String text = ::getValue<String>(labelText);
 
         if (text.isNotEmpty()) {
             if (!label) {
                 label = std::make_unique<ObjectLabel>(object);
+                object->cnv->addChildComponent(label.get());
             }
 
             auto bounds = getLabelBounds();
 
-            bounds.translate(0, fontHeight / -2.0f);
+            bounds.translate(0, bounds.getHeight() / -2.0f);
 
-            label->setFont(Font(fontHeight));
+            label->setFont(Font(bounds.getHeight()));
             label->setBounds(bounds);
             label->setText(text, dontSendNotification);
 
             label->setColour(Label::textColourId, getLabelColour());
 
-            object->cnv->addAndMakeVisible(label.get());
+            label->setVisible(true);
         } else {
+            if (label)
+                label->setVisible(false);
             label.reset(nullptr);
         }
     }


### PR DESCRIPTION
* fix IEM labels not updating correctly when changed (canvas used PD label text- which could change 'after' the label has been set via message snooping)
:warning: Label updates has a jitter, so they don't update consistently, when they are being updated at a fixed rate (60hz etc), looks like this may come from the snooping system itself?
* fix connection display not showing extended characters (don't use monospace) show how many items are in a list for connection display 
* fix moving objects reading PD bounds 'as they are being dragged'

### with fix:
https://github.com/plugdata-team/plugdata/assets/12004932/ee17a2fc-673a-44c2-b169-a5eb6c5e6c6b

### without fix:
https://github.com/plugdata-team/plugdata/assets/12004932/8ea7c3e9-c53c-40d6-b56c-5d25de37c3aa

<details><summary>Test patch (from @tomara-x) :</summary>
<p>

```
#N canvas 827 239 527 327 12;
#X msg -513 396 label \$1, f 17;
#X obj -513 438 bng 127 250 50 0 empty empty ☢️ 75 81 0 32 #181818 #181818 #ffea00;
#X obj -513 114 t b f b, f 16;
#X msg -513 246 adddollar \$1, f 21;
#X msg -513 296 set symbol, f 20;
#X msg -513 164 list 👻 🧵 🪡 🦋 🦀 🐐 🍀 🍄 🌕 🌖 🌗 🌘 🌑 🌒 🌓 🌔 🌟 💧 🎷 🎲 🚁 🐭 🔪 🪞 🧿 🧹 🩸 🪱 🧸 💜 ☮ 🆘 🆒 🆓 🖤 ⚧ ☢️ ☣️ 🦊 💎 🐶 🦝 🔮 🦈 🌸 🍑 🥦 🦗 🦐 🍤 🐛 🐠 🫧 🤍 🐸 🐍 🌊 🍡 🍠 🍥 🍙 🍰 🌠 🦞 🪸 🐞 🪲 🐌 🕊 🌿 🎱 🐳 💕 💋 🍧 🥥 ☄️ ☀️ 🐜 🦑 🪓 🕸 🧭 🎑 🌅 🌄 🌠 🎇 🎆 🌇 🌆 🌃 🌌 🌉 🌁, f 99;
#X obj -513 14 metro 1 60 persec, f 25;
#X obj -513 64 count 1 95, f 19;
#X obj -513 -62 tgl 46 0 empty empty empty 17 7 0 10 #191919 #d4d4d4 #d4d4d4 0 1;
#X msg -513 346 symbol \$37, f 12;
#X connect 0 0 1 0;
#X connect 2 0 5 0;
#X connect 2 1 3 0;
#X connect 2 2 4 0;
#X connect 3 0 9 0;
#X connect 4 0 9 0;
#X connect 5 0 9 0;
#X connect 6 0 7 0;
#X connect 7 0 2 0;
#X connect 8 0 6 0;
#X connect 9 0 0 0;
```

</p>
</details>