### PR TITLE
fixes #849

### DIFF
--- a/Source/Objects/FunctionObject.h
+++ b/Source/Objects/FunctionObject.h
@@ -255,8 +255,10 @@ public:
         arr[1] = newRange.second;
 
         if (auto function = ptr.get<t_fake_function>()) {
-            function->x_min = newRange.first;
-            function->x_max = newRange.second;
+            if (newRange.first <= function->x_min_point)
+                function->x_min = newRange.first;
+            if (newRange.second >= function->x_max_point)
+                function->x_max = newRange.second;
         }
     }
 


### PR DESCRIPTION
ensures that all points remain in visible range.
but if the range is reversed then the getRange() function fixes that, so you can have a min that's grater than the max.. anyways.. at least we don't have any invisible points now

https://github.com/plugdata-team/plugdata/assets/86204514/473467ea-1025-4496-aac5-b3ed73099fe5

