### PR TITLE
fix window-dragger to reflect changes in JUCE master

### DIFF
--- a/Source/Utility/WindowDragger.h
+++ b/Source/Utility/WindowDragger.h
@@ -23,7 +23,7 @@ public:
 
 #if JUCE_LINUX
         auto* peer = componentToDrag->getPeer();
-        peer->startHostManagedResize(peer->localToGlobal(mouseDownWithinTarget) * Desktop::getInstance().getGlobalScaleFactor(), ResizableBorderComponent::Zone(0));
+        peer->startHostManagedResize(e.getPosition(), ResizableBorderComponent::Zone(0));
 #endif
     }
 


### PR DESCRIPTION
host managed resize (_NET_WM_MOVERESIZE) uses root window coordinate space, so give it the current position of the mouse on the component, and deal with the transform inside the platform code