### PR TITLE
fix canvas viewport scrollbar hover bounds

### DIFF
--- a/Source/CanvasViewport.h
+++ b/Source/CanvasViewport.h
@@ -143,8 +143,15 @@ class CanvasViewport : public Viewport {
 
         bool hitTest(int x, int y) override
         {
-            if (thumbBounds.contains(x, y))
+            Rectangle<float> fullBounds;
+            if (isVertical)
+                fullBounds = thumbBounds.withY(2).withHeight(getHeight() - 4);
+            else
+                fullBounds = thumbBounds.withX(2).withWidth(getWidth() - 4);
+
+            if (fullBounds.contains(x, y))
                 return true;
+
             return false;
         }
 


### PR DESCRIPTION
activate canvas viewport scrollbars when hover over their whole area, not only thumbBounds

https://github.com/plugdata-team/plugdata/assets/12004932/306384d1-5369-4c68-99f1-646b56f54ef1

