### PR TITLE
Implement named undo-redo tooltips.

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -996,7 +996,7 @@ void Canvas::dragAndDropPaste(String const& patchString, Point<int> mousePos, in
             _this->grabKeyboardFocus();
     });
 
-    patch.startUndoSequence("DragAndDropPaste"); // TODO: we can add the name of the event that it's dragging from?
+    patch.startUndoSequence("Add object"); // TODO: we can add the name of the event that it's dragging from?
 
     auto patchSize = Point<int>(patchWidth, patchHeight);
     String translatedObjects = pd::Patch::translatePatchAsString(patchString, mousePos - (patchSize / 2.0f));
@@ -1030,14 +1030,14 @@ void Canvas::dragAndDropPaste(String const& patchString, Point<int> mousePos, in
 
     patch.deselectAll();
     pastedObjects.clear();
-    patch.endUndoSequence("DragAndDropPaste");
+    patch.endUndoSequence("Add object");
 
     updateSidebarSelection();
 }
 
 void Canvas::pasteSelection()
 {
-    patch.startUndoSequence("Paste");
+    patch.startUndoSequence("Paste object/s");
 
     // Paste at mousePos, adds padding if pasted the same place
     auto mousePosition = getMouseXYRelative();
@@ -1076,7 +1076,7 @@ void Canvas::pasteSelection()
 
     patch.deselectAll();
     pastedObjects.clear();
-    patch.endUndoSequence("Paste");
+    patch.endUndoSequence("Paste object/s");
 
     updateSidebarSelection();
 }
@@ -1086,7 +1086,7 @@ void Canvas::duplicateSelection()
     Array<Connection*> conInlets, conOutlets;
     auto selection = getSelectionOfType<Object>();
 
-    patch.startUndoSequence("Duplicate");
+    patch.startUndoSequence("Duplicate object/s");
 
     std::vector<t_gobj*> objectsToDuplicate;
     for (auto* object : selection) {
@@ -1178,12 +1178,13 @@ void Canvas::duplicateSelection()
         setSelected(obj, true);
     }
 
-    patch.endUndoSequence("Duplicate");
+    patch.endUndoSequence("Duplicate object/s");
     patch.deselectAll();
 }
 
 void Canvas::removeSelection()
 {
+    patch.startUndoSequence("Remove object/s");
     // Make sure object isn't selected and stop updating gui
     editor->sidebar->hideParameters();
     editor->showTouchSelectionHelper(false);
@@ -1224,6 +1225,8 @@ void Canvas::removeSelection()
     synchronise();
     handleUpdateNowIfNeeded();
 
+    patch.endUndoSequence("Remove object/s");
+
     patch.deselectAll();
 
     synchroniseSplitCanvas();
@@ -1231,7 +1234,7 @@ void Canvas::removeSelection()
 
 void Canvas::removeSelectedConnections()
 {
-    patch.startUndoSequence("Remove Connections");
+    patch.startUndoSequence("Remove connection/s");
 
     for (auto* con : connections) {
         if (con->isSelected()) {
@@ -1244,7 +1247,7 @@ void Canvas::removeSelectedConnections()
         }
     }
 
-    patch.endUndoSequence("Remove Connections");
+    patch.endUndoSequence("Remove connection/s");
 
     // Load state from pd
     synchronise();
@@ -1356,7 +1359,7 @@ void Canvas::encapsulateSelection()
     auto copied = String::fromUTF8(text, size);
 
     // Wrap it in an undo sequence, to allow undoing everything in 1 step
-    patch.startUndoSequence("encapsulate");
+    patch.startUndoSequence("Encapsulate");
 
     pd::Interface::removeObjects(patchPtr, objects);
 
@@ -1368,7 +1371,7 @@ void Canvas::encapsulateSelection()
     
     auto* newObject = pd::Interface::checkObject(lastObject.getRaw<t_pd>());
     if (!newObject) {
-        patch.endUndoSequence("encapsulate");
+        patch.endUndoSequence("Encapsulate");
         pd->unlockAudioThread();
         return;
     }
@@ -1385,7 +1388,7 @@ void Canvas::encapsulateSelection()
         }
     }
 
-    patch.endUndoSequence("encapsulate");
+    patch.endUndoSequence("Encapsulate");
 
     pd->unlockAudioThread();
 
@@ -1488,7 +1491,7 @@ void Canvas::alignObjects(Align alignment)
         return totalBounds;
     };
 
-    patch.startUndoSequence("align objects");
+    patch.startUndoSequence("Align objects");
 
     // mark canvas as dirty, and set undo for all positions
     auto patchPtr = patch.getPointer().get();
@@ -1600,7 +1603,7 @@ void Canvas::alignObjects(Align alignment)
         connection->forceUpdate();
     }
 
-    patch.endUndoSequence("align objects");
+    patch.endUndoSequence("Align objects");
 }
 
 void Canvas::undo()

--- a/Source/Components/Buttons.cpp
+++ b/Source/Components/Buttons.cpp
@@ -1,0 +1,26 @@
+/*
+ // Copyright (c) 2023 Alexander Mitchell
+ // For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ // WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#include "../PluginEditor.h"
+#include "Buttons.h"
+
+String MainToolbarButton::getTooltip()
+{
+    auto setTooltip = TextButton::getTooltip();
+    if (auto editor = dynamic_cast<PluginEditor*>(getParentComponent())) {
+        auto cnv = editor->getCurrentCanvas();
+        if (isUndo) {
+            setTooltip = "Undo";
+            if (getValue<bool>(editor->canUndo) && cnv->patch.lastUndoSequence != "")
+                setTooltip += ": " /* + cnv->patch.getTitle() + ": " */ + cnv->patch.lastUndoSequence;
+        } else if (isRedo) {
+            setTooltip = "Redo";
+            if (getValue<bool>(editor->canRedo) && cnv->patch.lastRedoSequence != "")
+                setTooltip += ": "  /* + cnv->patch.getTitle() + ": " */ + cnv->patch.lastRedoSequence;
+        }
+    }
+    return setTooltip;
+}

--- a/Source/Components/Buttons.h
+++ b/Source/Components/Buttons.h
@@ -1,9 +1,16 @@
 #pragma once
 
+#include "Constants.h"
+
 class MainToolbarButton : public TextButton {
 
 public:
     using TextButton::TextButton;
+
+    bool isUndo = false;
+    bool isRedo = false;
+
+    String getTooltip() override;
 
     void paint(Graphics& g) override
     {

--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -281,7 +281,7 @@ void Object::applyBounds()
         return;
 
     cnv->pd->lockAudioThread();
-    patch->startUndoSequence("resize");
+    patch->startUndoSequence("Resize");
 
     for (auto& [object, bounds] : newObjectSizes) {
         if (object->gui)
@@ -290,7 +290,7 @@ void Object::applyBounds()
 
     canvas_dirty(patchPtr, 1);
 
-    patch->endUndoSequence("resize");
+    patch->endUndoSequence("Resize");
 
     MessageManager::callAsync([cnv = SafePointer(this->cnv)] {
         if (cnv)
@@ -886,7 +886,7 @@ void Object::mouseUp(MouseEvent const& e)
         if (ds.objectSnappingInbetween) {
             auto* c = ds.connectionToSnapInbetween.getComponent();
 
-            cnv->patch.startUndoSequence("SnapInbetween");
+            cnv->patch.startUndoSequence("Snap inbetween");
 
             auto* checkedOut = pd::Interface::checkObject(c->outobj->getPointer());
             auto* checkedIn = pd::Interface::checkObject(c->inobj->getPointer());
@@ -899,7 +899,7 @@ void Object::mouseUp(MouseEvent const& e)
                 cnv->patch.createConnection(checkedSnapped, 0, checkedIn, c->inIdx);
             }
 
-            cnv->patch.endUndoSequence("SnapInbetween");
+            cnv->patch.endUndoSequence("Snap inbetween");
 
             ds.objectSnappingInbetween->iolets[0]->isTargeted = false;
             ds.objectSnappingInbetween->iolets[ds.objectSnappingInbetween->numInputs]->isTargeted = false;

--- a/Source/Pd/Interface.h
+++ b/Source/Pd/Interface.h
@@ -412,12 +412,24 @@ struct Interface {
         canvas_dirty(cnv, 1);
     }
 
+    static int getUndoSize(t_canvas* cnv)
+    {
+        auto* undo = canvas_undo_get(cnv)->u_queue;
+
+        int count = 0;
+        while(undo) {
+            count++;
+            undo = undo->next;
+        }
+        return count;
+    }
+
     static int canUndo(t_canvas* cnv)
     {
         t_undo* udo = canvas_undo_get(cnv);
 
         if (udo && udo->u_last) {
-            return strcmp(udo->u_last->name, "no");
+            return strcmp(udo->u_last->name, "no") != 0;
         }
 
         return 0;
@@ -428,7 +440,7 @@ struct Interface {
         t_undo* udo = canvas_undo_get(cnv);
 
         if (udo && udo->u_last && udo->u_last->next) {
-            return strcmp(udo->u_last->next->name, "no");
+            return strcmp(udo->u_last->next->name, "no") != 0;
         }
 
         return 0;

--- a/Source/Pd/Patch.cpp
+++ b/Source/Pd/Patch.cpp
@@ -134,6 +134,13 @@ void Patch::updateUndoRedoState()
     if (auto patch = ptr.get<t_glist>()) {
         canUndo = pd::Interface::canUndo(patch.get());
         canRedo = pd::Interface::canRedo(patch.get());
+
+        auto undoSize = pd::Interface::getUndoSize(patch.get());
+        if (undoQueueSize != undoSize) {
+            undoQueueSize = undoSize;
+            updateUndoRedoString();
+        }
+
     }
 }
 
@@ -537,27 +544,95 @@ void Patch::endUndoSequence(String const& name)
 {
     if (auto patch = ptr.get<t_glist>()) {
         canvas_undo_add(patch.get(), UNDO_SEQUENCE_END, instance->generateSymbol(name)->s_name, nullptr);
+
+        updateUndoRedoString();
     }
 }
 
 void Patch::undo()
 {
     if (auto patch = ptr.get<t_glist>()) {
-        setCurrent();
-        glist_noselect(patch.get());
-        libpd_this_instance()->pd_gui->i_editor->canvas_undo_already_set_move = 0;
+        //setCurrent();
+        //auto x = patch.get();
+        //glist_noselect(x);
+        //libpd_this_instance()->pd_gui->i_editor->canvas_undo_already_set_move = 0;
 
-        pd::Interface::undo(patch.get());
+        //pd::Interface::undo(patch.get());
+        canvas_undo_undo(patch.get());
+
+        updateUndoRedoString();
     }
 }
 
 void Patch::redo()
 {
     if (auto patch = ptr.get<t_glist>()) {
-        setCurrent();
-        glist_noselect(patch.get());
-        libpd_this_instance()->pd_gui->i_editor->canvas_undo_already_set_move = 0;
-        pd::Interface::redo(patch.get());
+        //setCurrent();
+        //auto x = patch.get();
+        //glist_noselect(x);
+        //libpd_this_instance()->pd_gui->i_editor->canvas_undo_already_set_move = 0;
+
+        //pd::Interface::redo(patch.get());
+        canvas_undo_redo(patch.get());
+
+        updateUndoRedoString();
+    }
+}
+
+void Patch::updateUndoRedoString()
+{
+    if (auto patch = ptr.get<t_glist>()) {
+        auto cnv = patch.get();
+        auto currentUndo = canvas_undo_get(cnv)->u_last;
+        auto undo = currentUndo;
+        auto redo = currentUndo->next;
+
+        auto undoDbg = undo;
+        auto redoDbg = redo;
+
+        lastUndoSequence = "";
+        lastRedoSequence = "";
+
+        // undo / redo list will contain libpd undo events
+        // take the first event that we have put there from plugdata
+        // which will start with a capital letter
+        while (undo) {
+            String undoName = undo->name;
+            if (undoName == "props") {
+                lastUndoSequence = "Change property";
+                break;
+            } else if (CharacterFunctions::isUpperCase(undoName[0])) {
+                lastUndoSequence = undoName;
+                break;
+            }
+            undo = undo->prev;
+        }
+
+        while (redo) {
+            String redoName = redo->name;
+            if (redoName == "props") {
+                lastRedoSequence = "Change property";
+                break;
+            } else if (CharacterFunctions::isUpperCase(redoName[0])) {
+                lastRedoSequence = redoName;
+                break;
+            }
+            redo = redo->next;
+        }
+//#define DEBUG_UNDO_QUEUE
+#ifdef DEBUG_UNDO_QUEUE
+        std::cout << "<<<<<< undo list:" << std::endl;
+        while (undoDbg) {
+            std::cout << undoDbg->name << std::endl;
+            undoDbg = undoDbg->prev;
+        }
+        std::cout << ">>>>>> redo list:" << std::endl;
+        while (redoDbg) {
+            std::cout << redoDbg->name << std::endl;
+            redoDbg = redoDbg->next;
+        }
+        std::cout << "-------------------" << std::endl;
+#endif
     }
 }
 

--- a/Source/Pd/Patch.h
+++ b/Source/Pd/Patch.h
@@ -119,10 +119,15 @@ public:
     bool closePatchOnDelete;
     bool openInPluginMode = false;
     int splitViewIndex = 0;
-    std::atomic<bool> canUndo = false;
-    std::atomic<bool> canRedo = false;
+    Value canUndo;
+    Value canRedo;
+
+    String lastUndoSequence;
+    String lastRedoSequence;
 
     int untitledPatchNum = 0;
+
+    void updateUndoRedoString();
 
 private:
     File currentFile;
@@ -132,6 +137,8 @@ private:
     friend class Instance;
     friend class Gui;
     friend class Object;
+
+    int undoQueueSize = 0;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Patch)
 };

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -85,6 +85,9 @@ public:
 
     void updateCommandStatus();
 
+    void updateUndoRedoButtonState();
+    void updateUndoRedoValueSource();
+
     bool isInterestedInFileDrag(StringArray const& files) override;
     void filesDropped(StringArray const& files, int x, int y) override;
     void fileDragEnter(StringArray const&, int, int) override;
@@ -124,8 +127,6 @@ public:
     std::unique_ptr<Sidebar> sidebar;
     std::unique_ptr<Statusbar> statusbar;
 
-    bool canUndo = false, canRedo = false;
-
     std::unique_ptr<Dialog> openedDialog;
 
     std::unique_ptr<PluginMode> pluginMode;
@@ -134,6 +135,9 @@ public:
 
     Value hvccMode;
     Value autoconnect;
+
+    Value canUndo;
+    Value canRedo;
 
     SplitView splitView;
     DrawableRectangle selectedSplitRect;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -543,11 +543,16 @@ void PluginProcessor::processBlock(AudioBuffer<float>& buffer, MidiBuffer& midiM
     if (oversampling > 0) {
         oversampler->processSamplesDown(targetBlock);
     }
-    
-    for(auto& patch : patches)
-    {
-        patch->updateUndoRedoState();
+
+    // limit the update frequency of the undo state, about 6x a second at 44100hz feels like enough?
+    static int processBlockCount = 0;
+    if (processBlockCount > 100) {
+        processBlockCount = 0;
+        for (auto& patch : patches) {
+            patch->updateUndoRedoState();
+        }
     }
+    processBlockCount++;
 
     auto targetGain = volume->load();
     float mappedTargetGain = 0.0f;

--- a/Source/Tabbar/SplitView.cpp
+++ b/Source/Tabbar/SplitView.cpp
@@ -163,6 +163,7 @@ void SplitView::setFocus(ResizableTabbedComponent* selectedTabComponent)
     if (activeTabComponent != selectedTabComponent) {
         activeTabComponent = selectedTabComponent;
         focusOutline->setActive(activeTabComponent);
+        editor->updateUndoRedoValueSource();
     }
 }
 

--- a/Source/Tabbar/Tabbar.cpp
+++ b/Source/Tabbar/Tabbar.cpp
@@ -588,6 +588,7 @@ void TabComponent::changeCallback(int newCurrentTabIndex, String const& newTabNa
             panelComponent->sendLookAndFeelChange();
             panelComponent->setVisible(true);
             panelComponent->toFront(true);
+            editor->updateUndoRedoValueSource();
         }
     }
     currentTabChanged(newCurrentTabIndex, newTabName);

--- a/Source/Utility/Fonts.h
+++ b/Source/Utility/Fonts.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <BinaryData.h>
+#include <JuceHeader.h>
 
 enum FontStyle {
     Regular,


### PR DESCRIPTION
The PR shows as a tooltop for the undo/redo buttons with the current undo/redo action.

To do this we have to check the size of the undo queue, and if it has grown change the text that is displayed. There is no (as best to my knowledge) way that PD can tell us if the undo queue has changed, other than us getting it's size.

Knowing if there is an undo/redo is not enough information, as when inside the queue, both will be true.

This PR also fixes issues with the undo system, that caused the undo state to be stale for the button state, by linking the button state to the undo/redo juce::Value.

When a patch is changed / loaded, it relinks the patches undo/redo values to that of the editor buttons.