### PR TITLE
fix object selection bounds, and add object silhouette when lasso is …

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -727,6 +727,17 @@ void Canvas::mouseDrag(MouseEvent const& e)
     // Drag lasso
     if (!(e.source.isTouch() && e.source.getIndex() != 0)) {
         lasso.dragLasso(e);
+        if (showObjectFullBounds)
+            return;
+
+        // check for minimum size lasso so not to trigger object silhouette with erroneous mouse movement
+        const auto smallRectangle = Rectangle<int>(0,0,5,5);
+        if (lasso.getLocalBounds().contains(smallRectangle)) {
+            showObjectFullBounds = true;
+            for (auto* object : objects) {
+                object->showFullBounds(true);
+            }
+        }
     }
 }
 
@@ -781,9 +792,11 @@ void Canvas::mouseUp(MouseEvent const& e)
 
     lasso.endLasso();
     isDraggingLasso = false;
-    for (auto* object : objects)
+    showObjectFullBounds = false;
+    for (auto* object : objects) {
         object->originalBounds = Rectangle<int>(0, 0, 0, 0);
-
+        object->showFullBounds(false);
+    }
     // TODO: this is a hack, find a better solution
     if (connectingWithDrag) {
         for (auto* obj : objects) {

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -218,6 +218,8 @@ private:
 
     RateReducer canvasRateReducer = RateReducer(90);
 
+    bool showObjectFullBounds = false;
+
     // Properties that can be shown in the inspector by right-clicking on canvas
     ObjectParameters parameters;
 

--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -501,6 +501,11 @@ void Object::triggerOverlayActiveState()
 
 void Object::paint(Graphics& g)
 {
+    if (showBoundsSilhouette) {
+        g.setColour(findColour(PlugDataColour::objectOutlineColourId).withAlpha(0.3f));
+        g.fillRoundedRectangle(getLocalBounds().reduced(Object::margin).toFloat(), Corners::objectCornerRadius);
+    }
+
     if ((showActiveState || isTimerRunning())) {
         g.setOpacity(activeStateAlpha);
         // show activation state glow
@@ -1324,6 +1329,14 @@ void Object::updateOverlays(int overlay)
     showActiveState = overlay & Overlay::ActivationState;
 
     if (indexWasShown != indexShown) {
+        repaint();
+    }
+}
+
+void Object::showFullBounds(bool isShown)
+{
+    if (showBoundsSilhouette != isShown) {
+        showBoundsSilhouette = isShown;
         repaint();
     }
 }

--- a/Source/Object.h
+++ b/Source/Object.h
@@ -73,6 +73,9 @@ public:
 
     void updateOverlays(int overlay);
 
+    // display the object bounds as a silhouette behind the object to aid in selection
+    void showFullBounds(bool isShown);
+
     void textEditorReturnKeyPressed(TextEditor& ed) override;
     void textEditorTextChanged(TextEditor& ed) override;
 
@@ -139,6 +142,8 @@ private:
     Image activityOverlayImage;
 
     ObjectDragState& ds;
+
+    bool showBoundsSilhouette = false;
 
     RateReducer rateReducer = RateReducer(ACTIVITY_UPDATE_RATE);
 

--- a/Source/Objects/ObjectBase.cpp
+++ b/Source/Objects/ObjectBase.cpp
@@ -286,7 +286,7 @@ bool ObjectBase::hitTest(int x, int y)
 // Gets position from pd and applies it to Object
 Rectangle<int> ObjectBase::getSelectableBounds()
 {
-    return object->getBounds() - cnv->canvasOrigin;
+    return object->getBounds().reduced(Object::margin) - cnv->canvasOrigin;
 }
 
 // Called in destructor of subpatch and graph class


### PR DESCRIPTION
…active (to aid in selection of transparent object, eg: comment & knob)