### PR TITLE
improve lasso selection with transparent object silhouette background

### DIFF
--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -110,6 +110,10 @@ void Object::initialise()
     originalBounds.setBounds(0, 0, 0, 0);
 
     updateOverlays(cnv->getOverlays());
+
+    // FIXME: in valueChanged, any value change triggers a repaint
+    isDraggingLasso.referTo(cnv->isDraggingLasso);
+    isDraggingLasso.addListener(this);
 }
 
 void Object::timerCallback()
@@ -166,7 +170,7 @@ void Object::valueChanged(Value& v)
             gui->lock(cnv->isGraph || locked == var(true) || commandLocked == var(true));
         }
     }
-
+    // FIXME: any value change triggers a repaint!
     repaint();
 }
 
@@ -501,6 +505,10 @@ void Object::triggerOverlayActiveState()
 
 void Object::paint(Graphics& g)
 {
+    if (gui && gui->isTransparent() && getValue<bool>(isDraggingLasso)) {
+        g.setColour(findColour(PlugDataColour::objectOutlineColourId).withAlpha(0.1f));
+        g.fillRoundedRectangle(getLocalBounds().reduced(Object::margin).toFloat(), Corners::objectCornerRadius);
+    }
     if ((showActiveState || isTimerRunning())) {
         g.setOpacity(activeStateAlpha);
         // show activation state glow

--- a/Source/Object.h
+++ b/Source/Object.h
@@ -136,6 +136,8 @@ private:
     bool isObjectMouseActive = false;
     bool isInsideUndoSequence = false;
 
+    Value isDraggingLasso;
+
     Image activityOverlayImage;
 
     ObjectDragState& ds;

--- a/Source/Objects/CanvasObject.h
+++ b/Source/Objects/CanvasObject.h
@@ -28,6 +28,11 @@ public:
         iemHelper.addIemParameters(objectParameters, false, true, 20, 12, 14);
     }
 
+    bool isTransparent() override
+    {
+        return true;
+    }
+
     void updateSizeProperty() override
     {
         setPdBounds(object->getObjectBounds());

--- a/Source/Objects/CommentObject.h
+++ b/Source/Objects/CommentObject.h
@@ -27,6 +27,11 @@ public:
         isDraggingLasso.addListener(this);
     }
 
+    bool isTransparent() override
+    {
+        return true;
+    }
+
     void update() override
     {
         objectText = getText().trimEnd();

--- a/Source/Objects/KnobObject.h
+++ b/Source/Objects/KnobObject.h
@@ -212,6 +212,11 @@ public:
         objectParameters.addParamBool("Show arc", cAppearance, &showArc, { "No", "Yes" }, 1);
     }
 
+    bool isTransparent() override
+    {
+        return !::getValue<bool>(outline);
+    }
+
     void updateDoubleClickValue()
     {
         auto val = jmap<float>(::getValue<float>(initialValue), getMinimum(), getMaximum(), 0.0f, 1.0f);
@@ -434,10 +439,10 @@ public:
 
     void paint(Graphics& g) override
     {
-        bool selected = object->isSelected() && !cnv->isGraph;
-        auto outlineColour = object->findColour(selected ? PlugDataColour::objectSelectedOutlineColourId : objectOutlineColourId);
-
         if (::getValue<bool>(outline)) {
+            bool selected = object->isSelected() && !cnv->isGraph;
+            auto outlineColour = object->findColour(selected ? PlugDataColour::objectSelectedOutlineColourId : objectOutlineColourId);
+
             g.setColour(Colour::fromString(secondaryColour.toString()));
             g.fillRoundedRectangle(getLocalBounds().toFloat().reduced(0.5f), Corners::objectCornerRadius);
 
@@ -452,16 +457,19 @@ public:
             g.setColour(Colour::fromString(secondaryColour.toString()));
             g.fillEllipse(bounds);
 
-            g.setColour(outlineColour);
+            g.setColour(object->findColour(objectOutlineColourId));
             g.drawEllipse(bounds, 1.0f);
         }
     }
     
     void paintOverChildren(Graphics& g) override
     {
-        if(::getValue<bool>(isDraggingLasso))
+        bool selected = object->isSelected() && !cnv->isGraph;
+        if(::getValue<bool>(isDraggingLasso) || selected)
         {
-            g.setColour(object->findColour(PlugDataColour::objectOutlineColourId));
+            auto outlineColour = object->findColour(selected ? PlugDataColour::objectSelectedOutlineColourId : objectOutlineColourId);
+
+            g.setColour(outlineColour);
             g.drawRoundedRectangle(getLocalBounds().toFloat().reduced(0.5f), Corners::objectCornerRadius, 1.0f);
         }
     }

--- a/Source/Objects/NoteObject.h
+++ b/Source/Objects/NoteObject.h
@@ -102,6 +102,11 @@ public:
         objectParameters.addParamReceiveSymbol(&receiveSymbol);
     }
 
+    bool isTransparent() override
+    {
+        return true;
+    }
+
     void update() override
     {
         if (auto note = ptr.get<t_fake_note>()) {

--- a/Source/Objects/ObjectBase.h
+++ b/Source/Objects/ObjectBase.h
@@ -77,6 +77,8 @@ public:
     virtual void showEditor() { }
     virtual void hideEditor() { }
 
+    virtual bool isTransparent() { return false; };
+
     bool hitTest(int x, int y) override;
 
     // Some objects need to show/hide iolets when send/receive symbols are set

--- a/Source/Objects/PictureObject.h
+++ b/Source/Objects/PictureObject.h
@@ -49,6 +49,11 @@ public:
         objectParameters.addParamSendSymbol(&sendSymbol);
     }
 
+    bool isTransparent() override
+    {
+        return true;
+    }
+
     void mouseDown(MouseEvent const& e) override
     {
         if (!e.mods.isLeftButtonDown())


### PR DESCRIPTION
This PR gives the objectBase a virtual member to inform other classes that use it that it's transparent or not.
I have also made the Knob object consistent with other objects, that when it is selected, the selection is around it's full bounds - even when no knob background is shown. (as all other objects that are transparent do)