### PR TITLE
fallback to default if there is no filename

### DIFF
--- a/Source/Heavy/ExporterBase.h
+++ b/Source/Heavy/ExporterBase.h
@@ -129,7 +129,12 @@ struct ExporterBase : public Component
         auto projectCopyright = projectCopyrightValue.toString();
 
         if (!projectTitle.unquoted().containsNonWhitespaceChars())
-            projectTitle = patchFile.getFileNameWithoutExtension();
+        {
+            if (!realPatchFile.getFileNameWithoutExtension().isEmpty())
+                projectTitle = realPatchFile.getFileNameWithoutExtension();
+            else
+                projectTitle = "Untitled";
+        }
 
         // Add file location to search paths
         auto searchPaths = StringArray { patchFile.getParentDirectory().getFullPathName() };


### PR DESCRIPTION
This hopefully fixes https://github.com/plugdata-team/plugdata/issues/1322

Tested with projectTitle from:

- project
- patchname
- fallback

  
No idea about filenames with weird characters yet. Should probably be sanitized after this step?

This last fallback is for when you export a patch that you did not save, and you didn't put in a projectTitle in the field.