### PR TITLE
implemenet layer order option for search overview, (default layer order)

### DIFF
--- a/Source/Sidebar/SearchPanel.h
+++ b/Source/Sidebar/SearchPanel.h
@@ -9,6 +9,65 @@
 #include <m_pd.h>
 #include <m_imp.h>
 
+class SearchPanelSettings : public Component
+{
+public:
+    struct SearchPanelSettingsButton : public TextButton {
+        String const icon;
+        String const description;
+
+        SearchPanelSettingsButton(String iconString, String descriptionString)
+            : icon(std::move(iconString))
+            , description(std::move(descriptionString))
+        {
+            setClickingTogglesState(true);
+
+            auto sortLayerOrder = SettingsFile::getInstance()->getProperty<bool>("search_order");
+            setToggleState(sortLayerOrder, dontSendNotification);
+
+            onClick = [this](){
+                SettingsFile::getInstance()->setProperty("search_order", var(getToggleState()));
+            };
+        }
+
+        void paint(Graphics& g) override
+        {
+            auto colour = findColour(PlugDataColour::toolbarTextColourId);
+            if (isMouseOver()) {
+                colour = colour.contrasting(0.3f);
+            }
+
+            Fonts::drawText(g, description, getLocalBounds().withTrimmedLeft(32), colour, 14);
+
+            if (getToggleState()) {
+                colour = findColour(PlugDataColour::toolbarActiveColourId);
+            }
+
+            Fonts::drawIcon(g, icon, getLocalBounds().withTrimmedLeft(8), colour, 14, false);
+        }
+    };
+
+    SearchPanelSettings()
+    {
+        addAndMakeVisible(sortLayerOrder);
+
+        setSize(150, 28);
+    };
+
+    void resized() override
+    {
+        auto buttonBounds = getLocalBounds();
+
+        int buttonHeight = buttonBounds.getHeight();
+
+        sortLayerOrder.setBounds(buttonBounds.removeFromTop(buttonHeight));
+    }
+private:
+    SearchPanelSettingsButton sortLayerOrder = SearchPanelSettingsButton(Icons::AutoScroll, "Display layer order");
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SearchPanelSettings);
+};
+
 class SearchPanel : public Component, public KeyListener, public Timer
 {
 public:
@@ -97,6 +156,23 @@ public:
         auto colour = findColour(PlugDataColour::sidebarTextColourId);
         Fonts::drawIcon(g, Icons::Search, 2, 1, 32, colour, 12);
     }
+
+    std::unique_ptr<Component> getExtraSettingsComponent()
+    {
+        auto* settingsCalloutButton = new SmallIconButton(Icons::More);
+        settingsCalloutButton->setTooltip("Show search settings");
+        settingsCalloutButton->setConnectedEdges(12);
+        settingsCalloutButton->onClick = [this, settingsCalloutButton]() {
+            auto* editor = findParentComponentOfClass<PluginEditor>();
+            auto* sidebar = getParentComponent();
+            auto bounds = editor->getLocalArea(sidebar, settingsCalloutButton->getBounds());
+
+            auto docsSettings = std::make_unique<SearchPanelSettings>();
+            CallOutBox::launchAsynchronously(std::move(docsSettings), bounds, editor);
+        };
+
+        return std::unique_ptr<TextButton>(settingsCalloutButton);
+    }
     
     void updateResults()
     {
@@ -124,7 +200,7 @@ public:
         input.setBounds(inputBounds.reduced(5, 4));
         patchTree.setBounds(tableBounds);
     }
-    
+
     ValueTree generatePatchTree(pd::Patch::Ptr patch, void* topLevel = nullptr)
     {
         ValueTree patchTree("Patch");
@@ -132,46 +208,46 @@ public:
             if (auto object = objectPtr.get<t_pd>()) {
                 auto* top = topLevel ? topLevel : object.get();
                 String type = pd::Interface::getObjectClassName(object.get());
-                
-                if(!pd::Interface::checkObject(object.get())) continue;
-                
+
+                if (!pd::Interface::checkObject(object.get()))
+                    continue;
+
                 char* objectText;
                 int len;
                 pd::Interface::getObjectText(object.cast<t_text>(), &objectText, &len);
-                
+
                 int x, y, w, h;
                 pd::Interface::getObjectBounds(patch->getPointer().get(), object.cast<t_gobj>(), &x, &y, &w, &h);
-                
+
                 auto name = String::fromUTF8(objectText, len);
                 auto positionText = " (" + String(x) + ":" + String(y) + ")";
-                
+
                 ValueTree element("Object");
                 if (type == "canvas" || type == "graph") {
                     pd::Patch::Ptr subpatch = new pd::Patch(objectPtr, editor->pd, false);
                     ValueTree subpatchTree = generatePatchTree(subpatch, top);
                     element.copyPropertiesAndChildrenFrom(subpatchTree, nullptr);
-                    
+
                     element.setProperty("Name", name, nullptr);
                     element.setProperty("RightText", positionText, nullptr);
                     element.setProperty("Icon", canvas_isabstraction(subpatch->getPointer().get()) ? Icons::File : Icons::Object, nullptr);
                     element.setProperty("Object", reinterpret_cast<int64>(object.cast<void>()), nullptr);
                     element.setProperty("TopLevel", reinterpret_cast<int64>(top), nullptr);
-                }
-                else {
+                } else {
                     element.setProperty("Name", name.upToFirstOccurrenceOf(" ", false, false), nullptr);
                     element.setProperty("RightText", positionText, nullptr);
                     element.setProperty("Icon", Icons::Object, nullptr);
                     element.setProperty("Object", reinterpret_cast<int64>(object.cast<void>()), nullptr);
                     element.setProperty("TopLevel", reinterpret_cast<int64>(top), nullptr);
                 }
-                
+
                 patchTree.appendChild(element, nullptr);
             }
         }
 
         return patchTree;
     }
-     
+
     SafePointer<Canvas> currentCanvas;
     PluginEditor* editor;
     ValueTreeViewerComponent patchTree = ValueTreeViewerComponent("(Subpatch)");

--- a/Source/Sidebar/Sidebar.cpp
+++ b/Source/Sidebar/Sidebar.cpp
@@ -343,6 +343,8 @@ void Sidebar::updateExtraSettingsButton()
         extraSettingsButton = console->getExtraSettingsComponent();
     } else if (browser->isVisible()) {
         extraSettingsButton = browser->getExtraSettingsComponent();
+    } else if (searchPanel->isVisible()) {
+        extraSettingsButton = searchPanel->getExtraSettingsComponent();
     } else {
         extraSettingsButton.reset(nullptr);
         return;

--- a/Source/Utility/SettingsFile.h
+++ b/Source/Utility/SettingsFile.h
@@ -135,6 +135,8 @@ private:
             var(false)
 #endif
         },
+        // DEFAULT SETTINGS FOR TOGGLES
+        { "search_order", var(true) },
     };
 
     StringArray childTrees {


### PR DESCRIPTION
This PR allows the user to change the search panel sorting.

PD lists objects in the PD patch starting from 0, with new objects incrementing the index. However that order is reverse to the layer order (where top-most objects are higher index number).

So we can now reverse the list, to show objects that are 'above' another object on the canvas as 'above' the same object in the search list.

I have implemented a `more` menu in the search panel, to allow easy access to this option. As users may want to cross reference plugdata with a the patch as a text file, in which case they can change the ordering to PD (top is lower) ordering.