### PR TITLE
clear the search outliner when there is no active canvas

### DIFF
--- a/Source/Sidebar/SearchPanel.h
+++ b/Source/Sidebar/SearchPanel.h
@@ -115,6 +115,10 @@ public:
             currentCanvas->needsSearchUpdate = false;
             updateResults();
         }
+        if (!cnv) {
+            patchTree.clearValueTree();
+            stopTimer();
+        }
     }
     
     void visibilityChanged() override

--- a/Source/Utility/ValueTreeViewer.h
+++ b/Source/Utility/ValueTreeViewer.h
@@ -393,6 +393,12 @@ public:
         viewport.setViewPosition(originalViewPos);
     }
 
+    void clearValueTree()
+    {
+        ValueTree emptyTree;
+        setValueTree(emptyTree);
+    }
+
     ValueTree& getValueTree()
     {
         return valueTree;


### PR DESCRIPTION
When a user closes all patches, search outliner is still populated with last active patch data, this fixes that.
