### PR TITLE
directly clear search outliner when closing tab (don't stop timer, as…

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -808,6 +808,7 @@ void PluginEditor::closeTab(Canvas* cnv)
     auto patch = cnv->refCountedPatch;
 
     sidebar->hideParameters();
+    sidebar->clearSearchOutliner();
 
     patch->setVisible(false);
 

--- a/Source/Sidebar/SearchPanel.h
+++ b/Source/Sidebar/SearchPanel.h
@@ -105,6 +105,11 @@ public:
     {
         return false;
     }
+
+    void clear()
+    {
+        patchTree.clearValueTree();
+    }
     
     void timerCallback() override
     {
@@ -114,10 +119,6 @@ public:
             currentCanvas = cnv;
             currentCanvas->needsSearchUpdate = false;
             updateResults();
-        }
-        if (!cnv) {
-            patchTree.clearValueTree();
-            stopTimer();
         }
     }
     

--- a/Source/Sidebar/Sidebar.cpp
+++ b/Source/Sidebar/Sidebar.cpp
@@ -408,3 +408,8 @@ void Sidebar::updateConsole(int numMessages, bool newWarning)
 
     console->update();
 }
+
+void Sidebar::clearSearchOutliner()
+{
+    searchPanel->clear();
+}

--- a/Source/Sidebar/Sidebar.h
+++ b/Source/Sidebar/Sidebar.h
@@ -116,6 +116,8 @@ public:
     void clearConsole();
     void updateConsole(int numMessages, bool newWarning);
 
+    void clearSearchOutliner();
+
     void updateAutomationParameters();
 
     static constexpr int dragbarWidth = 6;


### PR DESCRIPTION
… currently that is what updates the panel)