### PR TITLE
Use same spelling for "centre_resized_canvas" so the setting works (U…

### DIFF
--- a/Source/CanvasViewport.h
+++ b/Source/CanvasViewport.h
@@ -395,7 +395,7 @@ public:
 
         adjustScrollbarBounds();
 
-        if (!SettingsFile::getInstance()->getProperty<bool>("center_resized_canvas")) {
+        if (!SettingsFile::getInstance()->getProperty<bool>("centre_resized_canvas")) {
             Viewport::resized();
             return;
         }


### PR DESCRIPTION
…K vs USA English)