### PR TITLE
Fix JUCE submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "JUCE"]
 	path = Libraries/JUCE
-	url = https://github.com/juce-framework/JUCE.git
+	url = https://github.com/plugdata-team/JUCE.git
 [submodule "Libraries/pure-data"]
 	path = Libraries/pure-data
 	url = https://github.com/plugdata-team/plugdata-pd
@@ -22,8 +22,6 @@
 [submodule "Libraries/juce-raw-keyboard-input-module"]
 	path = Libraries/juce-raw-keyboard-input-module
 	url = https://github.com/izzyreal/juce-raw-keyboard-input-module.git
-[submodule "./JUCE"]
-	url = https://github.com/plugdata-team/JUCE.git
 [submodule "Libraries/readerwriterqueue"]
 	path = Libraries/readerwriterqueue
 	url = https://github.com/cameron314/readerwriterqueue.git


### PR DESCRIPTION
The submodule URL for Libraries/JUCE refers to the upstream repository [juce-framework/JUCE](https://github.com/juce-framework/JUCE/), but the submodule points to a commit only found in the fork [plugdata-team/JUCE](https://github.com/plugdata-team/JUCE). This happens to work on GitHub, but is confusing and makes it difficult to find the actual repository (GitHub simply says the commit “may belong to a fork outside of the repository”, but isn't able to say which one).

This PR fixes the submodule URL and removes the unused `./JUCE` entry in .gitmodules.