### PR TITLE
render the activity dropshadow with a hole inside (so it doesn't show…

### DIFF
--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -1216,7 +1216,7 @@ void Object::render(NVGcontext* nvg)
         if(activityOverlayImage) nvgDeleteImage(nvg, activityOverlayImage);
         Path objectShadow;
         objectShadow.addRoundedRectangle(getLocalBounds().reduced(Object::margin - 1), Corners::objectCornerRadius);
-        activityOverlayImage = StackShadow::createDropShadowImage(nvg, getLocalBounds(), objectShadow, findColour(PlugDataColour::dataColourId), 5.5f, { 0, 0 }, 0);
+        activityOverlayImage = StackShadow::createActivityDropShadowImage(nvg, getLocalBounds(), objectShadow, findColour(PlugDataColour::dataColourId), 5.5f, { 0, 0 }, 0);
         activityOverlayDirty = false;
     }
     

--- a/Source/Utility/StackShadow.cpp
+++ b/Source/Utility/StackShadow.cpp
@@ -24,10 +24,23 @@ void StackShadow::renderDropShadow(juce::Graphics& g, juce::Path const& path, ju
 }
 
 
-int StackShadow::createDropShadowImage(NVGcontext* nvg, juce::Rectangle<int> bounds, juce::Path const& path, juce::Colour color, int radius, juce::Point<int> offset, int spread)
+int StackShadow::createActivityDropShadowImage(NVGcontext* nvg, juce::Rectangle<int> bounds, juce::Path const& path, juce::Colour color, int radius, juce::Point<int> offset, int spread)
 {
     Image shadow(Image::ARGB, bounds.getWidth(), bounds.getHeight(), true);
     Graphics g(shadow);
+
+    // make a hole in the middle of the dropshadow so that GOP doesn't render internal activity shadow
+    Path outside;
+    outside.addRectangle(0, 0, bounds.getWidth(), bounds.getHeight());
+    outside.setUsingNonZeroWinding(false);
+    Path inside;
+    auto boundsRounded = bounds.toFloat().reduced(6.5);
+    // FIXME: we need to offset by -0.5px because the whole shadow is +0.5 px offset incorrectly, remove this and fix alignment of the whole shadow
+    boundsRounded.translate(-0.5f, -0.5f);
+    inside.addRoundedRectangle(boundsRounded, radius - 2.5f, radius - 2.5f);
+    outside.addPath(inside);
+    g.reduceClipRegion(outside);
+
     renderDropShadow(g, path, color, radius, offset, spread);
     
     return NVGImageRenderer::convertImage(nvg, shadow);

--- a/Source/Utility/StackShadow.h
+++ b/Source/Utility/StackShadow.h
@@ -17,7 +17,7 @@ struct StackShadow : public juce::DeletedAtShutdown
     
     static void renderDropShadow(juce::Graphics& g, juce::Path const& path, juce::Colour color, int radius = 1, juce::Point<int> offset = { 0, 0 }, int spread = 0);
     
-    static int createDropShadowImage(NVGcontext* nvg, juce::Rectangle<int> bounds, juce::Path const& path, juce::Colour color, int radius = 1, juce::Point<int> offset = { 0, 0 }, int spread = 0);
+    static int createActivityDropShadowImage(NVGcontext* nvg, juce::Rectangle<int> bounds, juce::Path const& path, juce::Colour color, int radius = 1, juce::Point<int> offset = { 0, 0 }, int spread = 0);
     
     melatonin::DropShadow* dropShadow;
     


### PR DESCRIPTION
… through when rendering GOP's)

PROBLEM:
![image](https://github.com/plugdata-team/plugdata/assets/12004932/698e6a3f-300d-4c31-8701-b76bde2642b2)


FIX:
![image](https://github.com/plugdata-team/plugdata/assets/12004932/cc4ce908-cebc-40b3-9429-f4fbf33446c7)
