### PR TITLE
remove line packaging Manual dir

### DIFF
--- a/Resources/Scripts/package_resources.py
+++ b/Resources/Scripts/package_resources.py
@@ -113,7 +113,6 @@ copyFile("../../Libraries/pd-else/Documentation/README.pdf", "Extra/else")
 copyDir("../../Libraries/pd-else/Code_source/Compiled/audio/sfont~/sf", "Extra/else/sf")
 copyDir("../Patches/Presets", "./Extra/Presets")
 copyDir("../Patches/Palettes", "./Extra/palette")
-copyDir("../Documentation/Manual", "./Extra/Manual")
 globCopy("../../Libraries/pure-data/doc/sound/*", "Extra/else")
 
 # pd-lua


### PR DESCRIPTION
This is failing all the Linux builds because the packaging script doesn't go past this error.