### PR TITLE
implement send/receive as label tags in search

### DIFF
--- a/Source/Iolet.cpp
+++ b/Source/Iolet.cpp
@@ -53,7 +53,7 @@ Rectangle<int> Iolet::getCanvasBounds()
 
 void Iolet::render(NVGcontext* nvg)
 {
-    if (getValue<bool>(presentationMode) || insideGraph || hideIolet)
+    if (!isVisible())
         return;
 
     auto* fb = cnv->ioletBuffer;
@@ -451,5 +451,6 @@ void Iolet::valueChanged(Value& v)
 void Iolet::setHidden(bool hidden)
 {
     hideIolet = hidden;
+    setVisible(!getValue<bool>(presentationMode) && !insideGraph && !hideIolet);
     repaint();
 }

--- a/Source/Utility/ValueTreeNodeBranchLine.cpp
+++ b/Source/Utility/ValueTreeNodeBranchLine.cpp
@@ -21,3 +21,13 @@ void ValueTreeNodeBranchLine::mouseUp(MouseEvent const& e)
         viewerComponent->repaint();
     }
 }
+
+void ValueTreeNodeBranchLine::paint(Graphics& g)
+{
+    if (!treeLine.isEmpty()) {
+        auto colour = (isHover && !node->isOpenInSearchMode()) ? findColour(PlugDataColour::objectSelectedOutlineColourId) : findColour(PlugDataColour::panelTextColourId).withAlpha(0.25f);
+
+        g.reduceClipRegion(treeLineImage, AffineTransform());
+        g.fillAll(colour);
+    }
+}

--- a/Source/Utility/ValueTreeNodeBranchLine.h
+++ b/Source/Utility/ValueTreeNodeBranchLine.h
@@ -15,15 +15,7 @@ public:
     {
     }
 
-    void paint(Graphics& g) override
-    {
-        if (!treeLine.isEmpty()) {
-            auto colour = isHover ? findColour(PlugDataColour::objectSelectedOutlineColourId) : findColour(PlugDataColour::panelTextColourId).withAlpha(0.25f);
-
-            g.reduceClipRegion(treeLineImage, AffineTransform());
-            g.fillAll(colour);
-        }
-    }
+    void paint(Graphics& g) override;
 
     void mouseEnter(const MouseEvent& e) override
     {

--- a/Source/Utility/ValueTreeViewer.h
+++ b/Source/Utility/ValueTreeViewer.h
@@ -195,7 +195,7 @@ public:
             g.setColour(sendColour);
             auto tagBounds = itemBounds.removeFromLeft(length).translated(4, 0).reduced(0, 5).expanded(2, 0);
             //g.fillRect(tagBounds.withTop(getHeight() * 0.5f));
-            g.fillRoundedRectangle(tagBounds.toFloat(), Corners::defaultCornerRadius);
+            g.fillRoundedRectangle(tagBounds.toFloat(), Corners::defaultCornerRadius * 0.8f);
             Fonts::drawFittedText(g, sendSymbolText, tagBounds.translated(2,0), sendColour.contrasting());
             itemBounds.translate(8,0);
         }
@@ -208,7 +208,7 @@ public:
             g.setColour(recColour);
             auto tagBounds = itemBounds.removeFromLeft(length).translated(4, 0).reduced(0, 5).expanded(2, 0);
             //g.fillRect(tagBounds.withBottom(getHeight() * 0.5f));
-            g.fillRoundedRectangle(tagBounds.toFloat(), Corners::defaultCornerRadius);
+            g.fillRoundedRectangle(tagBounds.toFloat(), Corners::defaultCornerRadius * 0.8f);
             Fonts::drawFittedText(g, receiveSymbolText, tagBounds.translated(2,0), recColour.contrasting());
         }
 


### PR DESCRIPTION
* implement send/receive as label tags in search
* fix directory line highlighting when in search results mode
* fix reindexing of search not taking into account search string
* add "send" "receive" keywords to search
* add tooltip for search to explain keywords

Send/Receive tag example with patch from EwanBristow:
![image](https://github.com/plugdata-team/plugdata/assets/12004932/2ed3a594-affe-41b3-97d1-cee5462589f2)


