### PR TITLE
make sure connection layer is not visible when in plugin mode

### DIFF
--- a/Source/PluginMode.h
+++ b/Source/PluginMode.h
@@ -110,6 +110,8 @@ public:
         addAndMakeVisible(titleBar);
 
         setWidthAndHeight(1.0f);
+
+        cnv->connectionLayer.setVisible(false);
     }
 
     ~PluginMode() override = default;
@@ -199,6 +201,8 @@ public:
 
         editor->parentSizeChanged();
         editor->resized();
+
+        cnv->connectionLayer.setVisible(true);
 
 #if JUCE_LINUX
         editor->sendLookAndFeelChange(); // TODO: this is just a hacky way to make sure all framebuffers area cleared. could be cleaner.


### PR DESCRIPTION
If the user entered plugin mode from edit mode, then the JUCE connections could still be active, even if NVG wasn't rendering them, this forces them to be off.

However there could be a better way to do this?

Setting the connections to visible when leaving plugin mode looks ok, as the canvas then resets anyway