### PR TITLE
Change click to drop behaviour to release object on mouse up

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -1237,7 +1237,6 @@ void Canvas::dragAndDropPaste(String const& patchString, Point<int> mousePos, in
 {
     locked = false;
     presentationMode = false;
-    objectAdded = true;
 
     // force the valueChanged to run, and wait for them to return
     locked.getValueSource().sendChangeMessage(true);

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -251,8 +251,6 @@ public:
     
     Array<juce::WeakReference<NVGComponent>> drawables;
 
-    bool objectAdded = false;
-
 private:
     
     GlobalMouseListener globalMouseListener;

--- a/Source/Components/ObjectDragAndDrop.h
+++ b/Source/Components/ObjectDragAndDrop.h
@@ -194,7 +194,7 @@ public:
         setCentrePosition(mousePosition);
     }
 
-    void mouseDown(MouseEvent const& e) override
+    void mouseUp(MouseEvent const& e) override
     {
         // This is nicer, but also makes sure that getComponentAt doesn't return this object
         setVisible(false);

--- a/Source/Iolet.cpp
+++ b/Source/Iolet.cpp
@@ -149,9 +149,6 @@ void Iolet::mouseDrag(MouseEvent const& e)
 void Iolet::mouseDown(MouseEvent const& e)
 {
     mouseIsDown = true;
-
-    // make sure that intentional clicks on iolet get through after a DnD action
-    cnv->objectAdded = false;
 }
 
 void Iolet::mouseUp(MouseEvent const& e)
@@ -160,14 +157,6 @@ void Iolet::mouseUp(MouseEvent const& e)
     
     if (getValue<bool>(locked) || e.mods.isRightButtonDown())
         return;
-
-    // If an object is addded to canvas, the mouse can potentially be over an iolet when dropped onto canvas
-    // This situation could cause a cable to be created when an object is added
-    // Disregard mouseup if this happens
-    if (cnv->objectAdded) {
-        cnv->objectAdded = false;
-        return;
-    }
 
     // This might end up calling Canvas::synchronise, at which point we are not sure this class will survive, so we do an async call
 


### PR DESCRIPTION
This way we don't need to worry about iolets getting triggered on the mouse up, as the DnD action still has the mouse event