### PR TITLE
Added pure mode to hide status bar, palette bar, side bar for a more distraction free patching environment

### DIFF
--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -142,6 +142,7 @@ public:
     CallOutBox& showCalloutBox(std::unique_ptr<Component> content, Rectangle<int> screenBounds);
 
     void enablePluginMode(Canvas* cnv);
+    void enablePureMode(Canvas* cnv);
 
     void commandKeyChanged(bool isHeld) override;
     void setZoomLabelLevel(float value);
@@ -203,8 +204,9 @@ private:
     WindowDragger windowDragger;
 
     int const toolbarHeight = ProjectInfo::isStandalone ? 40 : 35;
+    bool isPureMode = false;
 
-    MainToolbarButton mainMenuButton, undoButton, redoButton, addObjectMenuButton, pluginModeButton;
+    MainToolbarButton mainMenuButton, undoButton, redoButton, addObjectMenuButton, pluginModeButton, pureModeButton;
     ToolbarRadioButton editButton, runButton, presentButton;
 
     CheckedTooltip tooltipWindow;


### PR DESCRIPTION
Hi, as the title says. I tested on WSL2 and it worked so far. I decided against an extra class because the UI-changes are quite small. 

I added a toggle next to the plugin mode button as seen in the screenshot. 
![Screenshot 2024-05-26 013204](https://github.com/plugdata-team/plugdata/assets/45923502/fbb3c671-eced-4475-b22a-a4618762454e)

I fixed a small typo too :)

Thank you!