### PR TITLE
use circular hittest when knob is borderless

### DIFF
--- a/Source/Object.cpp
+++ b/Source/Object.cpp
@@ -219,6 +219,22 @@ bool Object::hitTest(int x, int y)
     if (cnv->panningModifierDown())
         return false;
 
+    // Knob object is able to reduce its bounds when transparent.
+    // Use the objects hit-test if it is populated (currently only for knob)
+    if (transparentHitTest && (presentationMode.getValue() || locked.getValue() || commandLocked.getValue())) {
+        return transparentHitTest(x, y);
+    }
+
+    // Mouse over object
+    if (getLocalBounds().reduced(margin).contains(x, y)) {
+        return true;
+    }
+
+    // If the hit-test get's to here, and any of these are still true
+    // return! Otherwise it will test non-existent iolets and return true!
+    if ((presentationMode.getValue() || locked.getValue() || commandLocked.getValue()))
+        return false;
+
     // Mouse over iolets
     for (auto* iolet : iolets) {
         if (iolet->getBounds().contains(x, y))
@@ -237,11 +253,6 @@ bool Object::hitTest(int x, int y)
 
     if (gui && !gui->canReceiveMouseEvent(x, y)) {
         return false;
-    }
-
-    // Mouse over object
-    if (getLocalBounds().reduced(margin).contains(x, y)) {
-        return true;
     }
 
     return false;

--- a/Source/Object.h
+++ b/Source/Object.h
@@ -132,6 +132,8 @@ public:
 
     bool isSelected() const;
 
+    std::function<bool(int x, int y)> transparentHitTest = nullptr;
+
 private:
     void initialise();
 

--- a/Source/Objects/KnobObject.h
+++ b/Source/Objects/KnobObject.h
@@ -58,21 +58,6 @@ public:
         }
     }
 
-    bool hitTest(int x, int y) override
-    {
-        if (hasOutline) return true;
-
-        // If knob is circular limit hit test to circle, and expand more if there are ticks around the knob
-        auto centre = getLocalBounds().toFloat().getCentre();
-        auto knobRadius = getWidth() * 0.33f;
-        auto knobRadiusWithTicks = knobRadius + (getWidth() * 0.06f);
-        if (centre.getDistanceFrom(Point<float>(x, y)) < (ticks ? knobRadiusWithTicks : knobRadius)) {
-            return true;
-        }
-
-        return false;
-    }
-
     void mouseEnter(const MouseEvent& e) override
     {
         getParentComponent()->getProperties().set("hover", true);
@@ -216,6 +201,21 @@ public:
 
         knob.onDragEnd = [this]() {
             stopEdition();
+        };
+
+        object->transparentHitTest = [this, object](int x, int y) -> bool {
+                if (outline.getValue()) return true;
+
+                // If knob is circular limit hit test to circle, and expand more if there are ticks around the knob
+                auto hitPoint = getLocalPoint(object, Point<float>(x, y));
+                auto centre = getLocalBounds().toFloat().getCentre();
+                auto knobRadius = getWidth() * 0.33f;
+                auto knobRadiusWithTicks = knobRadius + (getWidth() * 0.06f);
+                if (centre.getDistanceFrom(hitPoint) < (ticks.getValue() ? knobRadiusWithTicks : knobRadius)) {
+                    return true;
+                }
+
+                return false;
         };
 
         onConstrainerCreate = [this]() {


### PR DESCRIPTION
* Fix object hittest when iolets are not selectable