### PR TITLE
Reset editor canvases state when leaving plugin mode.

### DIFF
--- a/Source/PluginMode.h
+++ b/Source/PluginMode.h
@@ -385,7 +385,6 @@ public:
 
 private:
     std::unique_ptr<Canvas> cnv;
-    SafePointer<Canvas> originalCanvas;
     PluginEditor* editor;
     ComponentPeer* desktopWindow;
 

--- a/Source/TabComponent.cpp
+++ b/Source/TabComponent.cpp
@@ -218,7 +218,6 @@ void TabComponent::handleAsyncUpdate()
         {
             if(patch->openInPluginMode) // Found pluginmode patch
             {
-                canvases.clear();
                 editor->pluginMode = std::make_unique<PluginMode>(editor, patch);
                 editor->resized();
                 lastPluginModePatchPtr = patch->getPointer().get();


### PR DESCRIPTION
Scale / Position / Mode is not saved in a PD-Patch, so we need to keep the canvases around, or have a way to save the old state and re-init