### PR TITLE
Block messages when first started, allow construction of editor to cl…

### DIFF
--- a/Source/Pd/MessageListener.h
+++ b/Source/Pd/MessageListener.h
@@ -171,7 +171,10 @@ private:
 
     std::unordered_map<void*, std::set<juce::WeakReference<MessageListener>>> messageListeners;
     CriticalSection messageListenerLock;
-    std::atomic<bool> block = false;
+
+    // Block messages unless an editor has been constructed
+    // Otherwise the message queue will not be cleared by the editors v-blank
+    std::atomic<bool> block = true;
 };
 
 }


### PR DESCRIPTION
…ear the block.

This stops message buildup when reopened in DAW and the editor has not become shown/hidden in order to set blocking to true.