### PR TITLE
Make stright connection setting use rounding of path width for segmen…

### DIFF
--- a/Source/Connection.cpp
+++ b/Source/Connection.cpp
@@ -178,12 +178,7 @@ void Connection::render(NVGcontext* nvg)
         dashColor.b *= 0.4f;
     }
 
-    float cableThickness;
-    switch (connectionStyle){
-        case PlugDataLook::ConnectionStyleVanilla:  cableThickness = cableType == SignalCable ? 4.5f : 2.5f;    break;
-        case PlugDataLook::ConnectionStyleThin:     cableThickness = 3.0f;                                      break;
-        default:                                    cableThickness = 4.5f;                                      break;
-    }
+    float cableThickness = getPathWidth();
 
     // Draw a fake path dot if the path is less than 1pt in length.
     // Paths don't draw currently if they have length of zero points
@@ -804,6 +799,20 @@ void Connection::pathChanged()
     repaint();
 }
 
+float const Connection::getPathWidth() {
+    switch (connectionStyle) {
+        case PlugDataLook::ConnectionStyleVanilla:
+            return (cableType == SignalCable) ? 4.5f : 2.5f;
+            break;
+        case PlugDataLook::ConnectionStyleThin:
+            return 3.0f;
+            break;
+        default:
+            return 4.5f;
+            break;
+    }
+}
+
 void Connection::reconnect(Iolet* target)
 {
     if (!reconnecting.isEmpty() || !target)
@@ -1089,7 +1098,9 @@ void Connection::updatePath()
             connectionPath.lineTo(currentPlan[n].toFloat());
         }
         connectionPath.lineTo(pend);
-        toDraw = connectionPath.createPathWithRoundedCorners(PlugDataLook::getUseStraightConnections() ? 0.0f : 8.0f);
+        // If theme is straight connections, make the rounded as small as the path width
+        // Otherwise the path generation will draw the path on-top of the curve (as path flattening happens from centre out)
+        toDraw = connectionPath.createPathWithRoundedCorners(PlugDataLook::getUseStraightConnections() ? getPathWidth() : 8.0f);
     }
     
     if(getPath() == toDraw) {

--- a/Source/Connection.h
+++ b/Source/Connection.h
@@ -122,6 +122,8 @@ private:
         
     void pathChanged() override;
 
+    const float getPathWidth();
+
     Array<SafePointer<Connection>> reconnecting;
     Rectangle<float> startReconnectHandle, endReconnectHandle;
 


### PR DESCRIPTION
…ted connections

This is to fix the UV coordinates not having enough points to draw corners correctly We make the curve the width of the path, so that the path does not overlap onto itself when drawn by GPU