### PR TITLE
Fix GOP error image

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -240,7 +240,7 @@ void Canvas::parentHierarchyChanged()
     // We need to do this because canvases are removed from the parent hierarchy when not visible
     // TODO: consider setting a flag when look and feel actually changes, and read that here
     if (getParentComponent()) {
-        lookAndFeelChanged();
+        sendLookAndFeelChange();
     }
 }
 

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -262,7 +262,6 @@ public:
     Component objectLayer;
     Component connectionLayer;
 
-    NVGFramebuffer ioletBuffer;
     NVGImage resizeHandleImage;
     NVGImage resizeGOPHandleImage;
     NVGImage presentationShadowImage;
@@ -272,7 +271,35 @@ public:
 
     Array<juce::WeakReference<NVGComponent>> drawables;
 
+    NVGcolor canvasBackgroundCol;
+    NVGcolor canvasMarkingsCol;
+    NVGcolor presentationBackgroundCol;
+    NVGcolor presentationWindowOutlineCol;
+
+    NVGcolor lassoCol;
+    NVGcolor lassoOutlineCol;
+
+    NVGcolor objectOutlineCol;
+    NVGcolor commentTextCol;
+    NVGcolor guiObjectInternalOutlineCol;
+    NVGcolor textObjectBackgroundCol;
+    NVGcolor transparentObjectBackgroundCol;
+    NVGcolor selectedOutlineCol;
+    NVGcolor indexTextCol;
+    NVGcolor ioletLockedCol;
+
+    NVGcolor dataCol;
+    NVGcolor sigCol;
+    NVGcolor gemCol;
+
+    NVGcolor dataColBrighter;
+    NVGcolor sigColBrighter;
+
 private:
+    void lookAndFeelChanged() override;
+
+    void parentHierarchyChanged() override;
+
     GlobalMouseListener globalMouseListener;
 
     bool dimensionsAreBeingEdited = false;

--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -279,11 +279,18 @@ public:
     NVGcolor lassoCol;
     NVGcolor lassoOutlineCol;
 
+    // objectOutlineColourId
     NVGcolor objectOutlineCol;
+
     NVGcolor commentTextCol;
+
+    // guiObjectInternalOutlineColour
     NVGcolor guiObjectInternalOutlineCol;
+
     NVGcolor textObjectBackgroundCol;
     NVGcolor transparentObjectBackgroundCol;
+
+    // objectSelectedOutlineColourId
     NVGcolor selectedOutlineCol;
     NVGcolor indexTextCol;
     NVGcolor ioletLockedCol;

--- a/Source/Objects/GraphOnParent.h
+++ b/Source/Objects/GraphOnParent.h
@@ -260,16 +260,13 @@ public:
             canvas->performRender(nvg, invalidArea);
         }
 
-        auto selectedOutlineColour = convertColour(cnv->editor->getLookAndFeel().findColour(PlugDataColour::objectSelectedOutlineColourId));
-        auto outlineColour = convertColour(cnv->editor->getLookAndFeel().findColour(PlugDataColour::objectOutlineColourId));
-
         if (isOpenedInSplitView) {
-            auto bgColour = cnv->editor->getLookAndFeel().findColour(PlugDataColour::guiObjectBackgroundColourId);
-
             auto width = getWidth();
             auto height = getHeight();
 
             if (openInGopBackground.needsUpdate(width, height)) {
+                auto bgColour = cnv->editor->getLookAndFeel().findColour(PlugDataColour::guiObjectBackgroundColourId);
+
                 openInGopBackground = NVGImage(nvg, width, height, [width, height, bgColour](Graphics &g) {
                     AffineTransform rotate;
                     rotate = rotate.rotated(MathConstants<float>::pi / 4.0f);
@@ -285,8 +282,10 @@ public:
                 });
             }
             auto imagePaint = nvgImagePattern(nvg, b.getX(), b.getY(), b.getWidth(), b.getHeight(), 0.0f, openInGopBackground.getImageId(), 1.0f);
+            nvgBeginPath(nvg);
+            nvgRoundedRect(nvg,  b.getX(), b.getY(), b.getWidth(), b.getHeight(), Corners::objectCornerRadius);
             nvgFillPaint(nvg, imagePaint);
-            nvgFillRoundedRect(nvg, b.getX(), b.getY(), b.getWidth(), b.getHeight(), Corners::objectCornerRadius);
+            nvgFill(nvg);
 
             Font fontMetrics;
             fontMetrics = Fonts::getDefaultFont().withHeight(12.0f);
@@ -298,13 +297,13 @@ public:
                 nvgBeginPath(nvg);
                 nvgFontFace(nvg, "Inter-Regular");
                 nvgFontSize(nvg, 12.0f);
-                nvgFillColor(nvg, convertColour(cnv->editor->getLookAndFeel().findColour(PlugDataColour::commentTextColourId))); // why comment colour?
+                nvgFillColor(nvg, cnv->commentTextCol); // why comment colour?
                 nvgTextAlign(nvg, NVG_ALIGN_MIDDLE | NVG_ALIGN_CENTER);
                 nvgText(nvg, b.getCentreX(), b.getCentreY(), errorText.toRawUTF8(), nullptr);
             }
         }
 
-        nvgDrawRoundedRect(nvg, b.getX(), b.getY(), b.getWidth(), b.getHeight(), nvgRGBAf(0, 0, 0, 0), object->isSelected() ? selectedOutlineColour : outlineColour, Corners::objectCornerRadius);
+        nvgDrawRoundedRect(nvg, b.getX(), b.getY(), b.getWidth(), b.getHeight(), nvgRGBAf(0, 0, 0, 0), object->isSelected() ? cnv->selectedOutlineCol : cnv->objectOutlineCol, Corners::objectCornerRadius);
 
         if (auto graph = ptr.get<t_glist>()) {
             drawTicksForGraph(nvg, graph.get(), this);
@@ -316,7 +315,7 @@ public:
         auto b = parent->getLocalBounds();
         t_float y1 = b.getY(), y2 = b.getBottom(), x1 = b.getX(), x2 = b.getRight();
 
-        nvgStrokeColor(nvg, convertColour(parent->cnv->findColour(PlugDataColour::guiObjectInternalOutlineColour)));
+        nvgStrokeColor(nvg, parent->cnv->guiObjectInternalOutlineCol);
         if (x->gl_xtick.k_lperb) {
             t_float f = x->gl_xtick.k_point;
             for (int i = 0; f < 0.99f * x->gl_x2 + 0.01f * x->gl_x1; i++, f += x->gl_xtick.k_inc) {

--- a/Source/Objects/IEMHelper.h
+++ b/Source/Objects/IEMHelper.h
@@ -29,9 +29,17 @@ public:
 
     void update()
     {
-        primaryColour = Colour(getForegroundColour()).toString();
-        secondaryColour = Colour(getBackgroundColour()).toString();
-        labelColour = Colour(getLabelColour()).toString();
+        bool colourHasChanged = false;
+        if (const auto col = getForegroundColour().toString(); col != primaryColour) {
+            primaryColour = col;
+            colourHasChanged = true;
+        }
+        if (const auto col = getBackgroundColour().toString(); col != secondaryColour) {
+            secondaryColour = col;
+            colourHasChanged = true;
+        }
+        // we only need the callback that colourHasChanged will trigger for the object ATM.
+        labelColour = getLabelColour().toString();
 
         gui->getLookAndFeel().setColour(Label::textWhenEditingColourId, cnv->editor->getLookAndFeel().findColour(Label::textWhenEditingColourId));
         gui->getLookAndFeel().setColour(Label::textColourId, Colour::fromString(primaryColour.toString()));
@@ -59,6 +67,10 @@ public:
         receiveSymbol = getReceiveSymbol();
 
         initialise = getInit();
+
+        // Let the object know the colour has changed, nbx & background (secondary) colour currently
+        if (colourHasChanged)
+            iemColourChangedCallback();
 
         gui->repaint();
     }
@@ -214,6 +226,8 @@ public:
             gui->getLookAndFeel().setColour(Label::textWhenEditingColourId, colour);
             gui->getLookAndFeel().setColour(TextEditor::textColourId, colour);
 
+            iemColourChangedCallback();
+
             gui->repaint();
         } else if (v.refersToSameSourceAs(secondaryColour)) {
             auto colour = Colour::fromString(secondaryColour.toString());
@@ -223,6 +237,8 @@ public:
             gui->getLookAndFeel().setColour(TextButton::buttonColourId, colour);
 
             gui->getLookAndFeel().setColour(Slider::backgroundColourId, colour);
+
+            iemColourChangedCallback();
 
             gui->repaint();
         } else if (v.refersToSameSourceAs(labelColour)) {
@@ -503,6 +519,8 @@ public:
             iemgui->x_ldy = position.y;
         }
     }
+
+    std::function<void()> iemColourChangedCallback = [](){};
 
     int iemgui_color_hex[30] = {
         16579836, 10526880, 4210752, 16572640, 16572608,

--- a/Source/Objects/NumberObject.h
+++ b/Source/Objects/NumberObject.h
@@ -24,6 +24,8 @@ class NumberObject final : public ObjectBase {
 
     float value = 0.0f;
 
+    NVGcolor backgroundCol;
+
 public:
     NumberObject(pd::WeakReference ptr, Object* object)
         : ObjectBase(ptr, object)
@@ -31,6 +33,10 @@ public:
         , iemHelper(ptr, object, this)
 
     {
+        iemHelper.iemColourChangedCallback = [this](){
+            backgroundCol = convertColour(iemHelper.getBackgroundColour());
+        };
+
         input.onEditorShow = [this]() {
             auto* editor = input.getCurrentTextEditor();
             startEdition();
@@ -289,11 +295,8 @@ public:
         auto b = getLocalBounds().toFloat();
 
         bool selected = object->isSelected() && !cnv->isGraph;
-        auto backgroundColour = convertColour(iemHelper.getBackgroundColour());
-        auto selectedOutlineColour = convertColour(cnv->editor->getLookAndFeel().findColour(PlugDataColour::objectSelectedOutlineColourId));
-        auto outlineColour = convertColour(cnv->editor->getLookAndFeel().findColour(PlugDataColour::objectOutlineColourId));
 
-        nvgDrawRoundedRect(nvg, b.getX(), b.getY(), b.getWidth(), b.getHeight(), backgroundColour, selected ? selectedOutlineColour : outlineColour, Corners::objectCornerRadius);
+        nvgDrawRoundedRect(nvg, b.getX(), b.getY(), b.getWidth(), b.getHeight(), backgroundCol, selected ? cnv->selectedOutlineCol : cnv->objectOutlineCol, Corners::objectCornerRadius);
 
         int const indent = 9;
         Rectangle<float> iconBounds = { static_cast<float>(b.getX() + 4), static_cast<float>(b.getY() + 4), static_cast<float>(indent - 4), static_cast<float>(b.getHeight() - 8) };
@@ -306,11 +309,9 @@ public:
         nvgLineTo(nvg, leftX, centreY - 5.0f);
         nvgClosePath(nvg);
 
-        auto normalColour = cnv->editor->getLookAndFeel().findColour(PlugDataColour::guiObjectInternalOutlineColour);
-        auto highlightColour = cnv->editor->getLookAndFeel().findColour(PlugDataColour::objectSelectedOutlineColourId);
         bool highlighed = hasKeyboardFocus(true) && ::getValue<bool>(object->locked);
 
-        nvgFillColor(nvg, convertColour(highlighed ? highlightColour : normalColour));
+        nvgFillColor(nvg, highlighed ? cnv->selectedOutlineCol : cnv->guiObjectInternalOutlineCol);
         nvgFill(nvg);
 
         input.render(nvg);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -33,6 +33,7 @@
 #include "Object.h"
 #include "PluginMode.h"
 #include "Components/TouchSelectionHelper.h"
+#include "NVGSurface.h"
 
 #if ENABLE_TESTING
 void runTests(PluginEditor* editor);
@@ -276,6 +277,8 @@ PluginEditor::PluginEditor(PluginProcessor& p)
 
     pd->messageDispatcher->setBlockMessages(false);
     pd->objectLibrary->waitForInitialisationToFinish();
+
+    lookAndFeelChanged();
 }
 
 PluginEditor::~PluginEditor()


### PR DESCRIPTION
Use shader not framebuffer for iolets (mildly faster on iGPU, and much simpler to understand and maintain) Remove findColour() from render path of Object & Canvas rendering Place canvas constant colours into canvas lookAndFeelChanged()