### PR TITLE
Set plugdata-fx CLAP_FEATURES value to "audio-effect"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,7 +515,7 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
 
   clap_juce_extensions_plugin(TARGET plugdata_fx
       CLAP_ID "com.timothyschoen.plugdata-fx"
-      CLAP_FEATURES "effect")
+      CLAP_FEATURES "audio-effect")
 
   if(VERBOSE)
   else()


### PR DESCRIPTION
The standard CLAP string for an effect plugin is "audio-effect", not "effect": https://github.com/free-audio/clap/blob/main/include/clap/plugin-features.h