### PR TITLE
Implement patch thumbnails for welcome panel.

### DIFF
--- a/Source/Components/WelcomePanel.h
+++ b/Source/Components/WelcomePanel.h
@@ -105,7 +105,7 @@ class WelcomePanel : public Component
 
                             // Calculate offsets to center the image
                             offsetX = (componentWidth - drawWidth) / 2;
-                            offsetY = (componentHeight - drawHeight) / 2;
+                            offsetY = (componentHeight - drawHeight - 16) / 2;
 
                             g.drawImage(thumbnailImageData, offsetX, offsetY, drawWidth, drawHeight, 0, 0, imageWidth, imageHeight);
                         }

--- a/Source/Components/WelcomePanel.h
+++ b/Source/Components/WelcomePanel.h
@@ -14,29 +14,58 @@ class WelcomePanel : public Component
     , public NVGComponent
     , public AsyncUpdater {
 
+    class TopFillAllRect : public Component {
+        Colour bgCol;
+    public:
+        TopFillAllRect(){};
+
+        void setBGColour(const Colour& col)
+        {
+            bgCol = col;
+            repaint();
+        }
+
+        void paint(Graphics& g) override
+        {
+            g.fillAll(bgCol);
+        }
+    };
+
     class WelcomePanelTile : public Component {
         WelcomePanel& parent;
         float snapshotScale;
         bool isHovered = false;
         String tileName, tileSubtitle;
+        File thumbnailImage;
         std::unique_ptr<Drawable> snapshot = nullptr;
         NVGImage titleImage, subtitleImage, snapshotImage;
+
+        Image thumbnailImageData;
+
+        int lastWidth = -1;
+        int lastHeight = -1;
         
     public:
         bool isFavourited;
         std::function<void()> onClick = []() {};
         std::function<void(bool)> onFavourite = nullptr;
 
-        WelcomePanelTile(WelcomePanel& welcomePanel, String name, String subtitle, String svgImage, Colour iconColour, float scale, bool favourited)
+        WelcomePanelTile(WelcomePanel& welcomePanel, String name, String subtitle, String svgImage, Colour iconColour, float scale, bool favourited, File thumbImage = File())
             : parent(welcomePanel)
             , snapshotScale(scale)
             , tileName(name)
             , tileSubtitle(subtitle)
             , isFavourited(favourited)
+            , thumbnailImage(thumbImage)
         {
-            snapshot = Drawable::createFromImageData(svgImage.toRawUTF8(), svgImage.getNumBytesAsUTF8());
-            if (snapshot) {
-                snapshot->replaceColour(Colours::black, iconColour);
+            if (thumbImage.existsAsFile()){
+                std::unique_ptr<InputStream> inputStream(File(thumbImage).createInputStream());
+                thumbnailImageData = ImageFileFormat::loadFrom(*inputStream);
+            } else {
+                snapshot = Drawable::createFromImageData(svgImage.toRawUTF8(), svgImage.getNumBytesAsUTF8());
+                if (snapshot) {
+                    snapshot->replaceColour(Colours::black, iconColour);
+                }
             }
 
             resized();
@@ -48,17 +77,71 @@ class WelcomePanel : public Component
 
             auto* nvg = dynamic_cast<NanoVGGraphicsContext&>(g.getInternalContext()).getContext();
             parent.drawShadow(nvg, getWidth(), getHeight());
-            
-            nvgDrawRoundedRect(nvg, bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight(), convertColour(findColour(PlugDataColour::canvasBackgroundColourId)), convertColour(findColour(PlugDataColour::toolbarOutlineColourId)), Corners::largeCornerRadius);
 
-            if (snapshot && !snapshotImage.isValid()) {
-                snapshotImage =  NVGImage(nvg, bounds.getWidth() * 2, (bounds.getHeight() - 32) * 2, [this](Graphics &g) {
-                    g.addTransform(AffineTransform::scale(2.0f));
-                    snapshot->drawAt(g, 0, 0, 1.0f);
-                });
+            if (thumbnailImageData.isValid()) {
+                if (!snapshotImage.isValid() || lastWidth != bounds.getWidth() || lastHeight != bounds.getHeight()) {
+                    lastWidth = bounds.getWidth();
+                    lastHeight = bounds.getHeight();
+
+                    snapshotImage =  NVGImage(nvg, bounds.getWidth() * 2, (bounds.getHeight() - 32) * 2, [this, bounds](Graphics &g) {
+                        g.addTransform(AffineTransform::scale(2.0f));
+                        if (thumbnailImageData.isValid()) {
+                            auto imageWidth = thumbnailImageData.getWidth();
+                            auto imageHeight = thumbnailImageData.getHeight();
+                            auto componentWidth = bounds.getWidth();
+                            auto componentHeight = bounds.getHeight();
+
+                            float imageAspect = static_cast<float>(imageWidth) / imageHeight;
+                            float componentAspect = static_cast<float>(componentWidth) / componentHeight;
+
+                            int drawWidth, drawHeight;
+                            int offsetX = 0, offsetY = 0;
+
+                            if (componentAspect < imageAspect) {
+                                // Component is wider than the image aspect ratio, scale based on height
+                                drawHeight = componentHeight;
+                                drawWidth = static_cast<int>(drawHeight * imageAspect);
+                            } else {
+                                // Component is taller than the image aspect ratio, scale based on width
+                                drawWidth = componentWidth;
+                                drawHeight = static_cast<int>(drawWidth / imageAspect);
+                            }
+
+                            // Calculate offsets to center the image
+                            offsetX = (componentWidth - drawWidth) / 2;
+                            offsetY = (componentHeight - drawHeight) / 2;
+
+                            g.drawImage(thumbnailImageData, offsetX, offsetY, drawWidth, drawHeight, 0, 0, imageWidth, imageHeight);
+                        }
+                    });
+                }
+            } else {
+                if (snapshot && !snapshotImage.isValid()) {
+                    snapshotImage =  NVGImage(nvg, bounds.getWidth() * 2, (bounds.getHeight() - 32) * 2, [this](Graphics &g) {
+                        g.addTransform(AffineTransform::scale(2.0f));
+                        snapshot->drawAt(g, 0, 0, 1.0f);
+                    });
+                }
             }
-            
-            snapshotImage.render(nvg, bounds.withTrimmedBottom(32));
+
+            nvgSave(nvg);
+            auto sB = bounds.toFloat().reduced(0.2f);
+            nvgRoundedScissor(nvg, sB.getX(), sB.getY(), sB.getWidth(), sB.getHeight(), Corners::largeCornerRadius);
+            if (thumbnailImageData.isValid()) {
+                // Render the thumbnail image file that is in the root dir of the pd patch
+                auto sB = bounds.toFloat().reduced(0.2f);
+                nvgFillPaint(nvg, nvgImagePattern(nvg, 0, 0, getWidth(), getHeight() - 32 - 12, 0, snapshotImage.getImageId(), 1));
+                nvgFillRect(nvg, sB.getX(), sB.getY(), sB.getWidth(), sB.getHeight() - 32);
+            } else {
+                // Otherwise render the generated snapshot
+                auto lB = bounds.toFloat().expanded(0.5f);
+                nvgDrawRoundedRect(nvg, lB.getX(), lB.getY(), lB.getWidth(), lB.getHeight(), convertColour(findColour(PlugDataColour::canvasBackgroundColourId)), convertColour(findColour(PlugDataColour::toolbarOutlineColourId)), Corners::largeCornerRadius);
+                snapshotImage.render(nvg, bounds.withTrimmedBottom(32));
+            }
+            nvgRestore(nvg);
+
+            auto lB = bounds.toFloat().expanded(0.5f);
+            nvgDrawRoundedRect(nvg, lB.getX(), lB.getY(), lB.getWidth(), lB.getHeight(), nvgRGBA(0,0,0,0), convertColour(findColour(PlugDataColour::toolbarOutlineColourId)), Corners::largeCornerRadius);
 
             auto hoverColour = findColour(PlugDataColour::toolbarHoverColourId).interpolatedWith(findColour(PlugDataColour::toolbarBackgroundColourId), 0.5f);
             
@@ -162,6 +245,9 @@ public:
 
         addChildComponent(recentlyOpenedViewport);
 
+        // A top rectangle component that hides anything behind (we use this instead of scissoring)
+        topFillAllRect.setBGColour(findColour(PlugDataColour::panelBackgroundColourId));
+
         setCachedComponentImage(new NVGSurface::InvalidationListener(editor->nvgSurface, this));
         triggerAsyncUpdate();
     }
@@ -195,6 +281,9 @@ public:
         int numColumns = std::max(1, totalWidth / (desiredTileWidth + tileSpacing));
         // Adjust the tile width to fit within the available width
         int actualTileWidth = (totalWidth - (numColumns - 1) * tileSpacing) / numColumns;
+
+        // Place a rectangle directly behind the newTile & openTile so to hide any content that draws behind it.
+        topFillAllRect.setBounds(0, 0, getWidth(), recentlyOpenedViewport.getY());
 
         if (newPatchTile)
             newPatchTile->setBounds(rowBounds.removeFromLeft(actualTileWidth));
@@ -245,6 +334,9 @@ public:
         newPatchTile->onClick = [this]() { editor->getTabComponent().newPatch(); };
         openPatchTile->onClick = [this]() { editor->getTabComponent().openPatch(); };
 
+        topFillAllRect.setBGColour(findColour(PlugDataColour::panelBackgroundColourId));
+        addAndMakeVisible(topFillAllRect);
+
         addAndMakeVisible(*newPatchTile);
         addAndMakeVisible(*openPatchTile);
 
@@ -260,28 +352,32 @@ public:
                 auto subTree = recentlyOpenedTree.getChild(i);
                 auto patchFile = File(subTree.getProperty("Path").toString());
                 auto patchImage = subTree.getProperty("PatchImage").toString();
+                auto patchThumbnail = File(patchFile.getParentDirectory().getFullPathName() + "\\" + patchFile.getFileNameWithoutExtension() + "_thumbnail.png");
 
                 auto favourited = subTree.hasProperty("Pinned") && static_cast<bool>(subTree.getProperty("Pinned"));
                 auto snapshotColour = LookAndFeel::getDefaultLookAndFeel().findColour(PlugDataColour::objectSelectedOutlineColourId).withAlpha(0.3f);
 
                 String silhoutteSvg;
-                if (patchImage.isEmpty() && patchFile.existsAsFile()) {
-                    silhoutteSvg = OfflineObjectRenderer::patchToSVG(patchFile.loadFileAsString());
+                if (patchThumbnail.existsAsFile()){
                 } else {
-                    MemoryOutputStream ostream;
-                    Base64::convertFromBase64(ostream, patchImage);
-                    MemoryInputStream istream(ostream.getMemoryBlock());
+                    if (patchImage.isEmpty() && patchFile.existsAsFile()) {
+                        silhoutteSvg = OfflineObjectRenderer::patchToSVG(patchFile.loadFileAsString());
+                    } else {
+                        MemoryOutputStream ostream;
+                        Base64::convertFromBase64(ostream, patchImage);
+                        MemoryInputStream istream(ostream.getMemoryBlock());
 
-                    while (!istream.isExhausted()) {
-                        int const x = istream.readCompressedInt();
-                        int const y = istream.readCompressedInt();
-                        int const w = istream.readCompressedInt();
-                        int const h = istream.readCompressedInt();
-                        float const rad = Corners::objectCornerRadius;
+                        while (!istream.isExhausted()) {
+                            int const x = istream.readCompressedInt();
+                            int const y = istream.readCompressedInt();
+                            int const w = istream.readCompressedInt();
+                            int const h = istream.readCompressedInt();
+                            float const rad = Corners::objectCornerRadius;
 
-                        silhoutteSvg += String::formatted("<rect x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" rx=\"%.1f\" ry=\"%.1f\" />\n", x, y, w, h, rad, rad);
+                            silhoutteSvg += String::formatted("<rect x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" rx=\"%.1f\" ry=\"%.1f\" />\n", x, y, w, h, rad, rad);
+                        }
+                        silhoutteSvg = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\">\n" + silhoutteSvg + "</svg>";
                     }
-                    silhoutteSvg = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\">\n" + silhoutteSvg + "</svg>";
                 }
 
                 auto openTime = Time(static_cast<int64>(subTree.getProperty("Time")));
@@ -296,7 +392,7 @@ public:
                 String time = openTime.toString(false, true, false, true);
                 String timeDescription = date + ", " + time;
 
-                auto* tile = tiles.add(new WelcomePanelTile(*this, patchFile.getFileName(), timeDescription, silhoutteSvg, snapshotColour, 1.0f, favourited));
+                auto* tile = tiles.add(new WelcomePanelTile(*this, patchFile.getFileName(), timeDescription, silhoutteSvg, snapshotColour, 1.0f, favourited, patchThumbnail));
                 tile->onClick = [this, patchFile]() mutable {
                     if(patchFile.existsAsFile()) {
                         editor->pd->autosave->checkForMoreRecentAutosave(patchFile, editor, [this, patchFile]() {
@@ -393,6 +489,8 @@ public:
 
     Component recentlyOpenedComponent;
     BouncingViewport recentlyOpenedViewport;
+
+    TopFillAllRect topFillAllRect;
 
     std::unique_ptr<NanoVGGraphicsContext> nvgContext = nullptr;
 

--- a/Source/Components/WelcomePanel.h
+++ b/Source/Components/WelcomePanel.h
@@ -105,7 +105,7 @@ class WelcomePanel : public Component
 
                             // Calculate offsets to center the image
                             offsetX = (componentWidth - drawWidth) / 2;
-                            offsetY = (componentHeight - drawHeight - 16) / 2;
+                            offsetY = (componentHeight - drawHeight - 32) / 2;
 
                             g.drawImage(thumbnailImageData, offsetX, offsetY, drawWidth, drawHeight, 0, 0, imageWidth, imageHeight);
                         }
@@ -123,20 +123,22 @@ class WelcomePanel : public Component
             nvgSave(nvg);
             auto sB = bounds.toFloat().reduced(0.2f);
             nvgRoundedScissor(nvg, sB.getX(), sB.getY(), sB.getWidth(), sB.getHeight(), Corners::largeCornerRadius);
+
+            auto lB = bounds.toFloat().expanded(0.5f);
+            // Draw background even for images incase there is a transparent PNG
+            nvgDrawRoundedRect(nvg, lB.getX(), lB.getY(), lB.getWidth(), lB.getHeight(), convertColour(findColour(PlugDataColour::canvasBackgroundColourId)), convertColour(findColour(PlugDataColour::toolbarOutlineColourId)), Corners::largeCornerRadius);
             if (thumbnailImageData.isValid()) {
                 // Render the thumbnail image file that is in the root dir of the pd patch
                 auto sB = bounds.toFloat().reduced(0.2f);
-                nvgFillPaint(nvg, nvgImagePattern(nvg, 0, 0, getWidth(), getHeight() - 32 - 12, 0, snapshotImage.getImageId(), 1));
+                nvgFillPaint(nvg, nvgImagePattern(nvg, sB.getX(), sB.getY(), sB.getWidth(), sB.getHeight() - 32, 0, snapshotImage.getImageId(), 1));
                 nvgFillRect(nvg, sB.getX(), sB.getY(), sB.getWidth(), sB.getHeight() - 32);
             } else {
                 // Otherwise render the generated snapshot
-                auto lB = bounds.toFloat().expanded(0.5f);
-                nvgDrawRoundedRect(nvg, lB.getX(), lB.getY(), lB.getWidth(), lB.getHeight(), convertColour(findColour(PlugDataColour::canvasBackgroundColourId)), convertColour(findColour(PlugDataColour::toolbarOutlineColourId)), Corners::largeCornerRadius);
                 snapshotImage.render(nvg, bounds.withTrimmedBottom(32));
             }
             nvgRestore(nvg);
 
-            auto lB = bounds.toFloat().expanded(0.5f);
+            // Draw border around
             nvgDrawRoundedRect(nvg, lB.getX(), lB.getY(), lB.getWidth(), lB.getHeight(), nvgRGBA(0,0,0,0), convertColour(findColour(PlugDataColour::toolbarOutlineColourId)), Corners::largeCornerRadius);
 
             auto hoverColour = findColour(PlugDataColour::toolbarHoverColourId).interpolatedWith(findColour(PlugDataColour::toolbarBackgroundColourId), 0.5f);

--- a/Source/Utility/SettingsFile.cpp
+++ b/Source/Utility/SettingsFile.cpp
@@ -199,7 +199,7 @@ void SettingsFile::addToRecentlyOpened(File const& path)
         recentlyOpened.addChild(subTree, 0, nullptr);
     }
 
-    while (recentlyOpened.getNumChildren() > 10) {
+    while (recentlyOpened.getNumChildren() > 20) {
         auto minTime = Time::getCurrentTime().toMilliseconds();
         int minIdx = -1;
 


### PR DESCRIPTION
* thumbnail file placed in root dir of patch with same name as PD file: 
if pd file is: `myFile.pd`, then thumbnail file is: `myFile_thumbnail.png`
* Increase size of recent items to 20
* Use rounded scissors for welcome tiles and clip top area with coloured rectangle
* Thumbnail will automatically fill the size of the tile.
* If no thumbnail is present or not png or corrupt, then SVG will be used

![image](https://github.com/user-attachments/assets/76d4b783-b128-4d31-bf57-c3f6ecad810a)

