### PR TITLE
improve temp runmode switching by Ctrl

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -1344,18 +1344,21 @@ void Canvas::mouseDown(MouseEvent const& e)
             dragState.wasDuplicated = false;
             cancelConnectionCreation();
 
-            if (e.mods.isCommandDown()) {
-                // Lock if cmd + click on canvas
-                deselectAll();
+            if (SettingsFile::getInstance()->getProperty<bool>("cmd_click_switches_mode")) {
+                if (e.mods.isCommandDown()) {
+                    // Lock if cmd + click on canvas
+                    deselectAll();
 
-                presentationMode.setValue(false);
+                    presentationMode.setValue(false);
 
-                // when command + click on canvas, swap between locked / edit mode
-                locked.setValue(!locked.getValue());
-                locked.getValueSource().sendChangeMessage(true);
+                    // when command + click on canvas, swap between locked / edit mode
+                    locked.setValue(!locked.getValue());
+                    locked.getValueSource().sendChangeMessage(true);
 
-                updateOverlays();
+                    updateOverlays();
+                }
             }
+
             if (!e.mods.isShiftDown()) {
                 deselectAll();
             }

--- a/Source/Dialogs/AdvancedSettingsPanel.h
+++ b/Source/Dialogs/AdvancedSettingsPanel.h
@@ -52,6 +52,10 @@ public:
         showPalettesValue.addListener(this);
         interfaceProperties.add(new PropertiesPanel::BoolComponent("Show palette bar", showPalettesValue, { "No", "Yes" }));
 
+        commandClickSwitchesModeValue.referTo(settingsFile->getPropertyAsValue("cmd_click_switches_mode"));
+        commandClickSwitchesModeValue.addListener(this);
+        interfaceProperties.add(new PropertiesPanel::BoolComponent("Command/Ctrl + click on canvas switches mode", commandClickSwitchesModeValue, { "No", "Yes" }));
+
         showAllAudioDeviceValues.referTo(settingsFile->getPropertyAsValue("show_all_audio_device_rates"));
         showAllAudioDeviceValues.addListener(this);
         otherProperties.add(new PropertiesPanel::BoolComponent("Show all audio device rates", showAllAudioDeviceValues, { "No", "Yes" }));
@@ -189,6 +193,7 @@ public:
     Value nativeDialogValue;
     Value autosaveInterval;
     Value autosaveEnabled;
+    Value commandClickSwitchesModeValue;
 
     Value patchDownwardsOnly;
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -955,11 +955,12 @@ void PluginEditor::handleAsyncUpdate()
 
     if (auto* cnv = getCurrentCanvas()) {
         bool locked = getValue<bool>(cnv->locked);
+        bool commandLocked = getValue<bool>(cnv->commandLocked);
         bool isDragging = cnv->dragState.didStartDragging && !cnv->isDraggingLasso && cnv->locked == var(false);
 
         if (getValue<bool>(cnv->presentationMode)) {
             presentButton.setToggleState(true, dontSendNotification);
-        } else if (locked) {
+        } else if (locked || commandLocked) {
             runButton.setToggleState(true, dontSendNotification);
         } else {
             editButton.setToggleState(true, dontSendNotification);

--- a/Source/Utility/SettingsFile.h
+++ b/Source/Utility/SettingsFile.h
@@ -154,6 +154,7 @@ private:
         { "search_xy_show", var(true) },
         { "search_index_show", var(false) },
         { "open_patches_in_window", var(false) },
+        { "cmd_click_switches_mode", var(true) },
     };
 
     StringArray childTrees {


### PR DESCRIPTION
Hi would like to address #1959 with my patch. I guessed this is intended behavior by the comments so I put it behind a config option and preserved the original behavior by default

Also fixed a small bug where the mode button state wasn't updating correct with ctrl held and clicking something. Now it should reflect actual locked state when clicking