### PR TITLE
Fix welcome panel NVG window occluding the DnD highlight

### DIFF
--- a/Source/Components/WelcomePanel.h
+++ b/Source/Components/WelcomePanel.h
@@ -372,6 +372,11 @@ class WelcomePanel : public Component
             return Rectangle<int>(20, getHeight() - 80, 16, 16);
         }
 
+        bool hitTest(int x, int y) override
+        {
+            return getLocalBounds().reduced(12).contains(Point<int>(x, y));
+        }
+
         void mouseEnter(MouseEvent const& e) override
         {
             isHovered = true;

--- a/Source/Components/WelcomePanel.h
+++ b/Source/Components/WelcomePanel.h
@@ -180,6 +180,11 @@ class WelcomePanel : public Component
                     break;
             }
         }
+
+        bool hitTest(int x, int y)
+        {
+            return getLocalBounds().reduced(12).contains(Point<int>(x, y));
+        }
         
         void mouseEnter(MouseEvent const& e) override
         {

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -214,6 +214,8 @@ private:
 
     static inline int numEditors = 0;
 
+    Rectangle<int> workArea;
+
     // Used in plugin
     std::unique_ptr<MouseRateReducedComponent<ResizableCornerComponent>> cornerResizer;
 


### PR DESCRIPTION
We reduce the edges of the NVG window, and paint in the remaining area in editor to fake it.

![image](https://github.com/user-attachments/assets/86fe9371-a713-432a-9581-82066edeb35b)
