### PR TITLE
Add Perfetto performance debug library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,7 @@
 [submodule "Libraries/fuzzysearchdatabase"]
 	path = Libraries/fuzzysearchdatabase
 	url = https://timschoen@bitbucket.org/j_norberg/fuzzysearchdatabase.git
+[submodule "Libraries/melatonin_perfetto"]
+	path = Libraries/melatonin_perfetto
+	url = https://github.com/sudara/melatonin_perfetto.git
+	branch = main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(ENABLE_SFIZZ "" ON)
 option(ENABLE_FFMPEG "" ON)
 option(ENABLE_GEM "" ON)
 option(ENABLE_ASAN "" OFF)
+option(ENABLE_PERFETTO "" OFF)
 option(MACOS_LEGACY "" OFF)
 option(VERBOSE "" OFF)
 
@@ -86,6 +87,9 @@ set(ENABLE_SFIZZ OFF)
 endif()
 
 add_subdirectory(Libraries/ EXCLUDE_FROM_ALL)
+if(ENABLE_PERFETTO)
+  add_subdirectory(Libraries/melatonin_perfetto EXCLUDE_FROM_ALL)
+endif()
 
 cmake_policy(SET CMP0091 NEW)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -249,6 +253,7 @@ set(PLUGDATA_COMPILE_DEFINITIONS
     PLUGDATA_GIT_HASH="${GIT_HASH}"
     PD=1
     ENABLE_TESTING=${ENABLE_TESTING}
+    PERFETTO=${ENABLE_PERFETTO}
 )
 if(ENABLE_SFIZZ)
   list(APPEND PLUGDATA_COMPILE_DEFINITIONS ENABLE_SFIZZ=1)
@@ -334,6 +339,10 @@ list(APPEND PLUGDATA_INCLUDE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Libraries/JU
 list(APPEND PLUGDATA_INCLUDE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Libraries/readerwriterqueue/")
 list(APPEND PLUGDATA_INCLUDE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Libraries/concurrentqueue/")
 list(APPEND PLUGDATA_INCLUDE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Libraries/BarelyML/")
+if(ENABLE_PERFETTO)
+  list(APPEND PLUGDATA_INCLUDE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/_deps/perfetto-src/sdk")
+  list(APPEND PLUGDATA_INCLUDE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Libraries/melatonin_perfetto")
+endif()
 list(APPEND PLUGDATA_INCLUDE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Source/")
 
 add_library(plugdata_core STATIC ${plugdata_sources} ${plugdata_global_sources})
@@ -614,6 +623,22 @@ else()
   target_link_libraries(plugdata_standalone PRIVATE plugdata_core pd)
 endif()
 
+if(ENABLE_PERFETTO)
+  if(MSVC)
+    target_compile_options(perfetto
+        PUBLIC "/MT$<$<STREQUAL:$<CONFIGURATION>,Debug>:d>"
+    )
+    set_target_properties(perfetto PROPERTIES CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>$" )
+  endif()
+
+  target_link_libraries(plugdata PRIVATE Melatonin::Perfetto)
+  target_link_libraries(plugdata_fx PRIVATE Melatonin::Perfetto)
+  target_link_libraries(plugdata_standalone PRIVATE Melatonin::Perfetto)
+  if(APPLE)
+    target_link_libraries(plugdata_midi PRIVATE Melatonin::Perfetto)
+  endif()
+endif()
+
 set_target_properties(plugdata_standalone PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PLUGDATA_PLUGINS_LOCATION}/Standalone)
 set_target_properties(plugdata_standalone PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PLUGDATA_PLUGINS_LOCATION}/Standalone)
 set_target_properties(plugdata_standalone PROPERTIES BUNDLE_OUTPUT_DIRECTORY ${PLUGDATA_PLUGINS_LOCATION}/Standalone)
@@ -676,6 +701,9 @@ elseif(UNIX AND NOT APPLE) # Linux or BSD
       install(FILES ${CMAKE_SOURCE_DIR}/Resources/Icons/plugdata_logo_linux.png DESTINATION share/icons/hicolor/512x512/apps RENAME plugdata.png)
       install(FILES ${CMAKE_SOURCE_DIR}/Resources/Installer/plugdata.desktop DESTINATION share/applications)
       install(PROGRAMS ${PLUGDATA_PLUGINS_LOCATION}/Standalone/plugdata DESTINATION bin)
+if(APPLE)
+target_include_directories(plugdata_midi PUBLIC "$<BUILD_INTERFACE:${PLUGDATA_INCLUDE_DIRECTORY}>")
+endif()
     else()
       install(DIRECTORY ${PLUGDATA_PLUGINS_LOCATION}/VST3/plugdata.vst3 DESTINATION "$ENV{HOME}/.vst3")
       install(DIRECTORY ${PLUGDATA_PLUGINS_LOCATION}/VST3/plugdata-fx.vst3 DESTINATION "$ENV{HOME}/.vst3")

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ cmake --build .
 - Extra build options:
   - -DQUICK_BUILD=1 will skip objects that take a long time to compile (All Gem objects, sfz~ and ffmpeg based audio players)
   - Gem, sfz~ and ffmpeg can also be disabled separately by passing "-DENABLE_GEM=0", "-DENABLE_SFIZZ=0", "-DENABLE_FFMPEG=0"
+  - You can enable Google [Perfetto](https://perfetto.dev/) performance tracing library by passing -DENABLE_PERFETTO=1. This [blog post](https://melatonin.dev/blog/using-perfetto-with-juce-for-dsp-and-ui-performance-tuning/) gives more insight on how to use it.
+    - To trace function calls and get performance information, add `TRACE_COMPONENT()` to function bodies you want.
+    - A faster way is a Python 3 script `Resources/Scripts/add_perfetto_tracepoints.py` that will add `TRACE_COMPONENT()` calls to matched function bodies in provided `.cpp` files. This means you don't have to add `TRACE_COMPONENT()` everywhere by hand. To use the script you must have a recent `llvm` (>= 19.1.3) and compatible [`libclang`](https://pypi.org/project/libclang/) package installed.
+    - Recommended compiling with `Release` mode on for most accurate profiling information.
 
 ## Adding your own externals
 You can use externals inside plugdata's plugin version by recompiling the externals along with plugdata. This can be achieved by making the following modification to plugdata:

--- a/Resources/Scripts/add_perfetto_tracepoints.py
+++ b/Resources/Scripts/add_perfetto_tracepoints.py
@@ -81,6 +81,6 @@ if __name__ == "__main__":
             for root, dirs, files in os.walk(filename):
                 for fn in files:
                     if fn.endswith('.cpp'):
-                        insert_tracepoint_in_functions(fn)
+                        insert_tracepoint_in_functions(os.path.join(root, fn))
         else:
             print(f"!!! Invalid file: {filename} !!!")

--- a/Resources/Scripts/add_perfetto_tracepoints.py
+++ b/Resources/Scripts/add_perfetto_tracepoints.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+# This script insert Perfetto TRACE_COMPONENT() calls at top of matched function bodies in .cpp files
+# Requires latest libclang bindings (>= 19.1.3)
+# Either install from LLVM source or use unofficial `libclang` package on pip
+# Please put path to libclang .dll/.so at command line !!!
+
+import clang.cindex
+import re
+import sys
+import argparse
+import os
+
+parser = argparse.ArgumentParser(description="Insert perfetto tracepoints in given .cpp files. NOTE: Due to how the libclang works it won't work on .h files!")
+parser.add_argument('filenames', nargs='+', help='.cpp file(s) or directories to add to')
+parser.add_argument('--libclang-path', '-l', help='Path to libclang .dll/.so', default="C:/Program Files/LLVM/bin/libclang.dll")
+parser.add_argument('--regex', '-r', help='The regular expression of function name to match', default=".*")
+parser.add_argument('--macro', '-m', help='Macro/code to add at top of functions', default="TRACE_COMPONENT();")
+parser.add_argument('--dry-run', '-d', help='Do not modify code', action="store_true")
+args = parser.parse_args()
+
+PATTERN = re.compile(args.regex)
+
+def insert_tracepoint_in_functions(filename):
+    global PATTERN, args
+
+    print(f"===== {filename} =====")
+
+    clang.cindex.Config.set_library_file(args.libclang_path)
+    index = clang.cindex.Index.create()
+    translation_unit = index.parse(filename)
+    rewriter = clang.cindex.Rewriter.create(translation_unit)
+
+    insertions = []
+    for node in translation_unit.cursor.walk_preorder():
+        if node.kind in [clang.cindex.CursorKind.CXX_METHOD, clang.cindex.CursorKind.CONSTRUCTOR, clang.cindex.CursorKind.DESTRUCTOR]:
+            if node.is_definition() and PATTERN.search(node.spelling):
+                body = next(iter(x for x in node.get_children() if x.kind == clang.cindex.CursorKind.COMPOUND_STMT))
+                if body:
+                    # Check if already trace this method body
+                    already_traced = False
+                    for n in body.walk_preorder():
+                        # (vvv) What libclang reports for macro insertion (vvv)
+                        if n.kind == clang.cindex.CursorKind.OVERLOADED_DECL_REF and args.macro.startswith(n.spelling):
+                            already_traced = True
+                            break
+
+                    if already_traced:
+                        print(f"* Already traced: {node.spelling}")
+                        continue
+
+                    # Search for opening '{' token, insert after
+                    tokens = list(body.get_tokens())
+                    for i, token in enumerate(tokens):
+                        if token.kind == clang.cindex.TokenKind.PUNCTUATION and token.spelling == "{" and i < len(tokens) - 1:
+                            pos = tokens[i+1].extent.start
+                            print(f"+ Tracing {node.spelling} at line {pos.line}")
+                            insertions.append(pos)
+                            break
+
+    for pos in insertions:
+        # Maintain whitespace at beginning of next node pushed to next line
+        ws = " " * max(pos.column - 1, 0)
+        rewriter.insert_text_before(pos, f"{args.macro}\n\n{ws}")
+
+    if args.dry_run:
+        print("!!! No files changed for dry run !!!")
+    else:
+        rewriter.overwrite_changed_files()
+
+
+if __name__ == "__main__":
+    if not os.path.isfile(args.libclang_path):
+        raise RuntimeError(f"Can't find libclang dll/so library at {args.libclang_path}, please pass with -l <path/to/libclang.dll> on commandline !")
+
+    # If its file, read the file, else if directory read the .cpp files in it
+    for filename in args.filenames:
+        if os.path.isfile(filename):
+            insert_tracepoint_in_functions(filename)
+        elif os.path.isdir(filename):
+            for root, dirs, files in os.walk(filename):
+                for fn in files:
+                    if fn.endswith('.cpp'):
+                        insert_tracepoint_in_functions(fn)
+        else:
+            print(f"!!! Invalid file: {filename} !!!")

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -90,6 +90,10 @@ PluginProcessor::PluginProcessor()
     , internalSynth(std::make_unique<InternalSynth>())
     , hostInfoUpdater(this)
 {
+#if PERFETTO
+    MelatoninPerfetto::get().beginSession();
+#endif
+
     // Make sure to use dots for decimal numbers, pd requires that
     std::setlocale(LC_NUMERIC, "C");
 
@@ -183,6 +187,10 @@ PluginProcessor::~PluginProcessor()
 {
     // Deleting the pd instance in ~PdInstance() will also free all the Pd patches
     patches.clear();
+
+#if PERFETTO
+    MelatoninPerfetto::get().endSession();
+#endif
 }
 
 void PluginProcessor::flushMessageQueue()

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -9,6 +9,8 @@
 #include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_dsp/juce_dsp.h>
 
+#include <melatonin_perfetto/melatonin_perfetto.h>
+
 #include "Utility/Config.h"
 #include "Utility/Limiter.h"
 #include "Utility/SettingsFile.h"
@@ -221,6 +223,10 @@ private:
     std::unique_ptr<dsp::Oversampling<float>> oversampler;
 
     UnorderedMap<uint64_t, std::unique_ptr<Component>> textEditorDialogs;
+
+#if PERFETTO
+    std::unique_ptr<perfetto::TracingSession> tracingSession;
+#endif
 
     static inline String const else_version = "ELSE v1.0-rc12";
     static inline String const cyclone_version = "cyclone v0.9-0";

--- a/Source/Utility/NanoVGGraphicsContext.cpp
+++ b/Source/Utility/NanoVGGraphicsContext.cpp
@@ -4,6 +4,7 @@
 
 #include "NanoVGGraphicsContext.h"
 #include <BinaryData.h>
+#include <melatonin_perfetto/melatonin_perfetto.h>
 
 static int const maxImageCacheSize = 256;
 


### PR DESCRIPTION
Hi so in debugging issue let me share techinque I think may help other PlugData authors ?

This is Perfetto library developed by Google and was implemented in JUCE library by thirdparty code `melatonin_perfetto`

https://github.com/sudara/melatonin_perfetto

Enable Perfetto flag in cmake and have beautiful data visualization of code running placed on Desktop after program exit

![](https://github.com/user-attachments/assets/2894f3a2-6caf-430d-9a96-6fe0f3a56a8c)

See this blog by author: https://melatonin.dev/blog/using-perfetto-with-juce-for-dsp-and-ui-performance-tuning/

It is useful and realworld I could debug #1966 issue with it, found numerous non obvious performance fixes to speed up menu opening by ~alot%

There is not too much code to add for lib, only downside is Perfetto only operates on functions you trace manually by adding `TRACE_COMPONENT()` calls. So one must add `TRACE_COMPONENT()` everywhere to debug. Those macro are no-op when Perfetto is off

In debugging I added a lot of `TRACE_COMPONENT()` calls. I found I needed lots and lots or I would miss certain events and as was not too familiar with this codebase , I believed it may be good to keep them in ?

Upside is not having to spend hours and hours putting tracing everything you need everytime

Downside is code being littered with `TRACE_COMPONENT()` everywhere ...

But setup for Perfetto is same either way. Switch `ENABLE_PERFETTO` cmake flag and add `TRACE_COMPONENT()` calls to functions want to debug. And note it is usually best to compile `PERFETTO` as well as `Release` config to get more accurate stats Then switch off when building final program.

Can omit all `TRACE_COMPONENT()` stuffs if it's better, I split into own commit