### PR TITLE
improve menu opening performance

### DIFF
--- a/Source/Dialogs/ThemeSettingsPanel.h
+++ b/Source/Dialogs/ThemeSettingsPanel.h
@@ -545,9 +545,15 @@ public:
     void valueChanged(Value& v) override
     {
         if (v.refersToSameSourceAs(fontValue)) {
+            auto previousFontName = Fonts::getCurrentFont().toString();
+
             PlugDataLook::setDefaultFont(fontValue.toString());
             SettingsFile::getInstance()->setProperty("default_font", fontValue.getValue());
-            pd->updateAllEditorsLNF();
+
+            bool changed = previousFontName != Fonts::getCurrentFont().toString();
+            if (changed)
+                pd->updateAllEditorsLNF();
+
             return;
         }
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1289,6 +1289,9 @@ pd::Patch::Ptr PluginProcessor::loadPatch(String patchText)
 
 void PluginProcessor::setTheme(String themeToUse, bool force)
 {
+    if (themeToUse == currentThemeName)
+        return;
+
     auto oldThemeTree = settingsFile->getTheme(PlugDataLook::currentTheme);
     auto themeTree = settingsFile->getTheme(themeToUse);
     // Check if theme name is valid
@@ -1315,6 +1318,8 @@ void PluginProcessor::setTheme(String themeToUse, bool force)
     if ((propertyState == 1) || (propertyState == 0 ? static_cast<int>(previousIoletGeom) != static_cast<int>(currentIoletGeom) : 0)) {
         PluginEditor::updateIoletGeometryForAllObjects(this);
     }
+
+    currentThemeName = themeToUse;
 }
 
 void PluginProcessor::updateAllEditorsLNF()

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -149,6 +149,7 @@ public:
 
     AtomicValue<float>* volume;
     ValueTree pluginModeTheme;
+    String currentThemeName;
 
     SettingsFile* settingsFile;
 


### PR DESCRIPTION
Related #1966 , some performance improvements when opening settings menu

- Don't apply theme if it is the same
- Don't apply font is it is the same

Improves performance of settings menu very much

Note that for theme check, it checks by name instead of by theme tree. Because even though theme tree was (I guess) the same ? It still failed the check. And I assume theme names are unique

Also font comparison is by name too