### PR TITLE
Set command lock to false when canvas is constructed. Only a canvas u…

### DIFF
--- a/Source/Canvas.cpp
+++ b/Source/Canvas.cpp
@@ -316,6 +316,13 @@ Canvas::Canvas(PluginEditor* parent, pd::Patch::Ptr p, Component* parentGraph)
     commandLocked.referTo(pd->commandLocked);
     commandLocked.addListener(this);
 
+    // pd->commandLocked doesn't get updated when a canvas isn't active
+    // So we set it to false here when a canvas is remade
+    // Otherwise the last canvas could have set it true, and it would still be
+    // in that state without command actually being locked
+    if (!isGraph)
+        commandLocked.setValue(false);
+    
     // init border for testing
     settingsChanged("border", SettingsFile::getInstance()->getPropertyAsValue("border"));
 


### PR DESCRIPTION
…pdates the pd->commandLocked value, and previous canvas could have set it true (eg: if the canvas was closed with ctrl-w, then the last state of command is true)