### PR TITLE
add new nosimd property

### DIFF
--- a/Source/Heavy/DPFExporter.h
+++ b/Source/Heavy/DPFExporter.h
@@ -20,6 +20,8 @@ public:
     Value exportTypeValue = Value(var(1));
     Value pluginTypeValue = Value(var(1));
 
+    Value disableSIMD = Value(var(0));
+
     PropertiesPanelProperty* midiinProperty;
     PropertiesPanelProperty* midioutProperty;
 
@@ -50,6 +52,10 @@ public:
         pluginFormats.add(new PropertiesPanel::BoolComponent("JACK", jackEnableValue, { "No", "Yes" }));
         jackEnableValue.addListener(this);
 
+        PropertiesArray pro_properties;
+
+        pro_properties.add(new PropertiesPanel::BoolComponent("Disable SIMD", disableSIMD, { "No", "Yes" }));
+
         for (auto* property : properties) {
             property->setPreferredHeight(28);
         }
@@ -63,6 +69,7 @@ public:
 
         panel.addSection("DPF", properties);
         panel.addSection("Plugin formats", pluginFormats);
+        panel.addSection("Advanced", pro_properties);
     }
 
     ValueTree getState() override
@@ -82,6 +89,7 @@ public:
         stateTree.setProperty("jackEnableValue", getValue<int>(jackEnableValue), nullptr);
         stateTree.setProperty("exportTypeValue", getValue<int>(exportTypeValue), nullptr);
         stateTree.setProperty("pluginTypeValue", getValue<int>(pluginTypeValue), nullptr);
+        stateTree.setProperty("disableSIMD", getValue<int>(disableSIMD), nullptr);
 
         return stateTree;
     }
@@ -103,6 +111,7 @@ public:
         jackEnableValue = tree.getProperty("jackEnableValue");
         exportTypeValue = tree.getProperty("exportTypeValue");
         pluginTypeValue = tree.getProperty("pluginTypeValue");
+        disableSIMD = tree.getProperty("disableSIMD");
     }
 
     void valueChanged(Value& v) override
@@ -149,6 +158,8 @@ public:
         bool clap = getValue<int>(clapEnableValue);
         bool jack = getValue<int>(jackEnableValue);
 
+        bool nosimd = getValue<int>(disableSIMD);
+
         StringArray formats;
 
         if (lv2) {
@@ -191,6 +202,7 @@ public:
         }
 
         metaJson->setProperty("dpf", metaDPF);
+        metaJson->setProperty("nosimd", nosimd);
 
         args.add("-m" + createMetaJson(metaJson));
 


### PR DESCRIPTION
Requires new toolchain: https://github.com/plugdata-team/plugdata-heavy-toolchain/pull/33

Atm only works for ARM, but it will disable NEON SIMD which makes sure single sample processing works.

Could also be used in the future for pdext generator and potentially others.

Not useful for Daisy/OWL/WASM.