### PR TITLE
fix popup menu and tooltip scaling when loaded as a plugin

### DIFF
--- a/Source/Components/ArrowPopupMenu.h
+++ b/Source/Components/ArrowPopupMenu.h
@@ -49,12 +49,13 @@ public:
             menuToAttachTo->setBounds(menuToAttachTo->getBounds().translated(-15, menuMargin - 3));
         } else {
             // adjust the popupMenu to be in the correct y position
-            auto const menuBounds = menuToAttachTo->getScreenBounds().reduced(menuMargin + 5);
-            auto const targetBounds = targetComponent->getScreenBounds();
+            auto const menuBounds = menuToAttachTo->getBounds().reduced(menuMargin + 5);
+            auto const targetBounds = targetComponent->getBounds();
 
-            auto const yOffset = targetBounds.getBottom() - menuBounds.getBottom();
+            // TODO: this was totally broken as is for some reason so for now it's hard coded
+            int const yOffset = static_cast<int>(static_cast<float>(targetBounds.getBottom() - menuBounds.getBottom()) / getApproximateScaleFactorForComponent(menuToAttachTo));
 
-            menuToAttachTo->setBounds(menuToAttachTo->getBounds().translated(20, yOffset));
+            menuToAttachTo->setBounds(menuToAttachTo->getBounds().translated(30, -40));
         }
     }
 

--- a/Source/Components/CheckedTooltip.h
+++ b/Source/Components/CheckedTooltip.h
@@ -19,11 +19,6 @@ public:
     {
     }
 
-    float getDesktopScaleFactor() const override
-    {
-        return Component::getDesktopScaleFactor();
-    }
-
     void setVisible(bool const shouldBeVisible) override
     {
         if (shouldBeVisible && !isVisible()) {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -61,7 +61,7 @@ public:
 
     void timerCallback() override
     {
-        setBounds(target->getScreenBounds());
+        setBounds(target->getScreenBounds() / getDesktopScaleFactor());
     }
 
     void paint(Graphics& g) override
@@ -70,6 +70,12 @@ public:
             g.fillAll(findColour(PlugDataColour::popupMenuBackgroundColourId));
         }
     }
+
+
+    float getDesktopScaleFactor() const override
+    {
+        return getApproximateScaleFactorForComponent(target);
+    };
 
 private:
     WeakReference<Component> target;

--- a/Source/Sidebar/Console.h
+++ b/Source/Sidebar/Console.h
@@ -211,7 +211,7 @@ public:
                         auto* editor = findParentComponentOfClass<PluginEditor>();
                         editor->highlightSearchTarget(target, true);
                     });
-                    menu.showMenuAsync(PopupMenu::Options());
+                    menu.showMenuAsync(PopupMenu::Options().withTargetComponent(this));
                 }
 
                 if (e.mods.isShiftDown()) {
@@ -473,7 +473,8 @@ public:
         settingsCalloutButton->onClick = [this, settingsCalloutButton] {
             auto consoleSettings = std::make_unique<ConsoleSettings>(settingsValues);
             auto const bounds = settingsCalloutButton->getScreenBounds();
-            CallOutBox::launchAsynchronously(std::move(consoleSettings), bounds, nullptr);
+            auto* pluginEditor = findParentComponentOfClass<PluginEditor>();
+            pluginEditor->showCalloutBox(std::move(consoleSettings), bounds);
         };
 
         return std::unique_ptr<TextButton>(settingsCalloutButton);

--- a/Source/Sidebar/DocumentationBrowser.h
+++ b/Source/Sidebar/DocumentationBrowser.h
@@ -457,7 +457,7 @@ public:
             };
 
             auto docsSettings = std::make_unique<DocumentBrowserSettings>(openFolderCallback, resetFolderCallback);
-            CallOutBox::launchAsynchronously(std::move(docsSettings), bounds, nullptr);
+            editor->showCalloutBox(std::move(docsSettings), bounds);
         };
 
         return std::unique_ptr<TextButton>(settingsCalloutButton);

--- a/Source/Sidebar/Palettes.h
+++ b/Source/Sidebar/Palettes.h
@@ -376,7 +376,8 @@ public:
             PopupMenu menu;
             menu.addItem("Export palette", exportClicked);
             menu.addItem("Delete palette", deleteClicked);
-            menu.showMenuAsync(PopupMenu::Options());
+            auto const position = e.getScreenPosition();
+            menu.showMenuAsync(PopupMenu::Options().withTargetComponent(this).withTargetScreenArea(Rectangle<int>(position, position.translated(1, 1))));
         }
 
         TextButton::mouseDown(e);

--- a/Source/TabComponent.h
+++ b/Source/TabComponent.h
@@ -269,7 +269,8 @@ private:
                 });
 
                 // Show the popup menu at the mouse position
-                tabMenu.showMenuAsync(PopupMenu::Options().withMinimumWidth(150).withMaximumNumColumns(1));
+                auto position = e.getScreenPosition();
+                tabMenu.showMenuAsync(PopupMenu::Options().withMinimumWidth(150).withMaximumNumColumns(1).withTargetComponent(this).withTargetScreenArea(Rectangle<int>(position, position.translated(1, 1))));
             } else if (cnv && e.originalComponent == this) {
                 toFront(false);
                 parent->showTab(cnv, parent->tabbars[1].contains(this));


### PR DESCRIPTION
Ok this should work for the most part. The one thing I'm not totally sure about is how to handle the tooltips being drawn outside the plugin window. I'm assuming this goes against general plugin UI guidelines, right?

I left a couple of TODO comments as well for things that should probably be handled in a better way.