### PR TITLE
try escaping output and search paths

### DIFF
--- a/Source/Heavy/ExporterBase.h
+++ b/Source/Heavy/ExporterBase.h
@@ -128,7 +128,7 @@ struct ExporterBase : public Component
     void startExport(File const& outDir)
     {
         auto patchPath = patchFile.getFullPathName();
-        auto const& outPath = outDir.getFullPathName();
+        auto const& outPath = "\"" + outDir.getFullPathName() + "\"";
         auto projectTitle = projectNameValue.toString();
         auto projectCopyright = projectCopyrightValue.toString();
 
@@ -140,7 +140,7 @@ struct ExporterBase : public Component
         }
 
         // Add original file location to search paths
-        auto searchPaths = StringArray { realPatchFile.getParentDirectory().getFullPathName() };
+        auto searchPaths = StringArray { "\"" + realPatchFile.getParentDirectory().getFullPathName() + "\""};
 
         editor->pd->setThis();
 
@@ -149,12 +149,8 @@ struct ExporterBase : public Component
         int numItems;
         pd::Interface::getSearchPaths(paths, &numItems);
 
-        if (realPatchFile.existsAsFile()) {
-            searchPaths.add(realPatchFile.getParentDirectory().getFullPathName());
-        }
-
         for (int i = 0; i < numItems; i++) {
-            searchPaths.add(paths[i]);
+            searchPaths.add("\"" + String(paths[i]) + "\"");
         }
 
         // Make sure we don't add the file location twice


### PR DESCRIPTION
Trying to close https://github.com/plugdata-team/plugdata/issues/2174

Not yet working and likely needs a different solution for windows?

Right now I get:
```
Command: /home/dreamer/Documents/plugdata/Toolchain/bin/Heavy/Heavy /tmp/temp_7cf3d876.pd -o"/home/dreamer/Sources/_projects/_wasted/_hvcc/_plugdatatest/_cpp/path spaces test/abstraction_test" -nabstraction_test -v -p "/home/dreamer/Sources/_projects/_wasted/_hvcc/_plugdatatest/_cpp/path spaces test" "/home/dreamer/Documents/plugdata/Abstractions/else" "/home/dreamer/Documents/plugdata/Abstractions/cyclone" "/home/dreamer/Documents/plugdata/Abstractions/heavylib" "/home/dreamer/Documents/plugdata/Abstractions" "/home/dreamer/Documents/plugdata/Externals" "/home/dreamer/Documents/plugdata/Extra/else" "/home/dreamer/Documents/plugdata/Extra/Gem" "/home/dreamer/Documents/plugdata/Extra"
--> Generating C
  1) [91mError[0m pd2hv:  in "" @ (x:0, y:0): Don't know how to parse object "jn.noise". Is it an object supported by Heavy? Is it an abstraction? Have the search paths been correctly configured?
  2) [91mError[0m pd2hv:  in "" @ (x:0, y:0): There was an error while connecting two objects. Have all objects been correctly instantiated? Have all inlets and outlets been declared?
  3) [91mError[0m pd2hv:  in "" @ (x:0, y:0): There was an error while connecting two objects. Have all objects been correctly instantiated? Have all inlets and outlets been declared?
Total compile time: 5.13ms
```

However if I run the exact command on the cli by hand it works correctly.