### PR TITLE
Heavy path escape

### DIFF
--- a/Source/Heavy/CppExporter.h
+++ b/Source/Heavy/CppExporter.h
@@ -38,7 +38,7 @@ public:
 #else
         auto const heavyPath = heavyExecutable.getFullPathName();
 #endif
-        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
+        StringArray args = { heavyPath.quoted(), pdPatch.quoted(), "-o", outdir.quoted() };
 
         args.add("-n" + name);
 

--- a/Source/Heavy/CppExporter.h
+++ b/Source/Heavy/CppExporter.h
@@ -59,8 +59,9 @@ public:
         if (shouldQuit)
             return true;
 
-        exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
-        start(args);
+        auto const command = args.joinIntoString(" ");
+        exportingView->logToConsole("Command: " + command + "\n");
+        Toolchain::startShellScript(command, this);
 
         waitForProcessToFinish(-1);
         exportingView->flushConsole();

--- a/Source/Heavy/CppExporter.h
+++ b/Source/Heavy/CppExporter.h
@@ -49,12 +49,10 @@ public:
 
         args.add("-v");
 
-        String paths = "-p";
+        args.add("-p");
         for (auto& path : searchPaths) {
-            paths += " " + path;
+            args.add(path);
         }
-
-        args.add(paths);
 
         if (shouldQuit)
             return true;

--- a/Source/Heavy/CppExporter.h
+++ b/Source/Heavy/CppExporter.h
@@ -29,13 +29,17 @@ public:
         projectCopyrightValue = tree.getProperty("projectCopyrightValue");
     }
 
-    bool performExport(String pdPatch, String const outdir, String name, String const copyright, StringArray searchPaths) override
+    bool performExport(String const& pdPatch, String const& outdir, String const& name, String const& copyright, StringArray const& searchPaths) override
     {
         exportingView->showState(ExportingProgressView::Exporting);
 
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
+#if JUCE_WINDOWS
+        auto const heavyPath = heavyExecutable.getFullPathName().replaceCharacter('\\', '/');
+#else
+        auto const heavyPath = heavyExecutable.getFullPathName();
+#endif
+        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
 
-        name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {

--- a/Source/Heavy/CppExporter.h
+++ b/Source/Heavy/CppExporter.h
@@ -33,14 +33,14 @@ public:
     {
         exportingView->showState(ExportingProgressView::Exporting);
 
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o" + outdir };
+        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
 
         name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {
             args.add("--copyright");
-            args.add("\"" + copyright + "\"");
+            args.add(copyright.quoted());
         }
 
         args.add("-v");
@@ -55,9 +55,8 @@ public:
         if (shouldQuit)
             return true;
 
-        auto compileString = args.joinIntoString(" ");
-        exportingView->logToConsole("Command: " + compileString + "\n");
-        start(compileString);
+        exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
+        start(args);
 
         waitForProcessToFinish(-1);
         exportingView->flushConsole();

--- a/Source/Heavy/DPFExporter.h
+++ b/Source/Heavy/DPFExporter.h
@@ -267,8 +267,8 @@ public:
             auto path = "export PATH=\"$PATH:" + Toolchain::dir.getChildFile("bin").getFullPathName().replaceCharacter('\\', '/') + "\"\n";
             auto cc = "CC=" + Toolchain::dir.getChildFile("bin").getChildFile("gcc.exe").getFullPathName().replaceCharacter('\\', '/') + " ";
             auto cxx = "CXX=" + Toolchain::dir.getChildFile("bin").getChildFile("g++.exe").getFullPathName().replaceCharacter('\\', '/') + " ";
-
-            Toolchain::startShellScript(path + cc + cxx + make.getFullPathName().replaceCharacter('\\', '/') + " -j4 -f " + makefile.getFullPathName().replaceCharacter('\\', '/'), this);
+            auto shell = " SHELL=" + Toolchain::dir.getChildFile("bin").getChildFile("bash.exe").getFullPathName().replaceCharacter('\\', '/').quoted();
+            Toolchain::startShellScript(path + cc + cxx + make.getFullPathName().replaceCharacter('\\', '/') + " -j4 -f " + makefile.getFullPathName().replaceCharacter('\\', '/') + shell, this);
 
 #else // Linux or BSD
             auto prepareEnvironmentScript = Toolchain::dir.getChildFile("scripts").getChildFile("anywhere-setup.sh").getFullPathName() + "\n";

--- a/Source/Heavy/DPFExporter.h
+++ b/Source/Heavy/DPFExporter.h
@@ -136,14 +136,14 @@ public:
     {
         exportingView->showState(ExportingProgressView::Exporting);
 
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o" + outdir };
+        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
 
         name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {
             args.add("--copyright");
-            args.add("\"" + copyright + "\"");
+            args.add(copyright.quoted());
         }
 
         auto makerName = getValue<String>(makerNameValue);
@@ -221,9 +221,8 @@ public:
         if (shouldQuit)
             return true;
 
-        auto compileString = args.joinIntoString(" ");
-        exportingView->logToConsole("Command: " + compileString + "\n");
-        start(compileString);
+        exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
+        start(args);
 
         waitForProcessToFinish(-1);
         exportingView->flushConsole();

--- a/Source/Heavy/DPFExporter.h
+++ b/Source/Heavy/DPFExporter.h
@@ -132,13 +132,17 @@ public:
         }
     }
 
-    bool performExport(String pdPatch, String outdir, String name, String copyright, StringArray searchPaths) override
+    bool performExport(String const& pdPatch, String const& outdir, String const& name, String const& copyright, StringArray const& searchPaths) override
     {
         exportingView->showState(ExportingProgressView::Exporting);
 
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
+#if JUCE_WINDOWS
+        auto const heavyPath = heavyExecutable.getFullPathName().replaceCharacter('\\', '/');
+#else
+        auto const heavyPath = heavyExecutable.getFullPathName();
+#endif
+        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
 
-        name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {

--- a/Source/Heavy/DPFExporter.h
+++ b/Source/Heavy/DPFExporter.h
@@ -211,18 +211,17 @@ public:
         args.add("-v");
         args.add("-gdpf");
 
-        String paths = "-p";
+        args.add("-p");
         for (auto& path : searchPaths) {
-            paths += " " + path;
+            args.add(path);
         }
-
-        args.add(paths);
 
         if (shouldQuit)
             return true;
 
-        exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
-        start(args);
+        auto const command = args.joinIntoString(" ");
+        exportingView->logToConsole("Command: " + command + "\n");
+        Toolchain::startShellScript(command, this);
 
         waitForProcessToFinish(-1);
         exportingView->flushConsole();

--- a/Source/Heavy/DPFExporter.h
+++ b/Source/Heavy/DPFExporter.h
@@ -141,7 +141,7 @@ public:
 #else
         auto const heavyPath = heavyExecutable.getFullPathName();
 #endif
-        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
+        StringArray args = { heavyPath.quoted(), pdPatch.quoted(), "-o", outdir.quoted() };
 
         args.add("-n" + name);
 

--- a/Source/Heavy/DaisyExporter.h
+++ b/Source/Heavy/DaisyExporter.h
@@ -249,14 +249,15 @@ public:
         auto size = getValue<int>(patchSizeValue);
         auto appType = getValue<int>(appTypeValue);
 
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o" + outdir };
+        
+        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir};
 
         name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {
             args.add("--copyright");
-            args.add("\"" + copyright + "\"");
+            args.add(copyright.quoted());
         }
 
         // set board definition
@@ -331,7 +332,7 @@ public:
 
         metaJson->setProperty("daisy", metaDaisy);
         auto metaJsonFile = createMetaJson(metaJson);
-        args.add("-m" + metaJsonFile.getFullPathName());
+        args.add("-m" + metaJsonFile.getFullPathName().quoted());
 
         args.add("-v");
         args.add("-gdaisy");
@@ -343,9 +344,8 @@ public:
 
         args.add(paths);
 
-        auto compileString = args.joinIntoString(" ");
-        exportingView->logToConsole("Command: " + compileString + "\n");
-        start(compileString);
+        exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
+        start(args);
         waitForProcessToFinish(-1);
         exportingView->flushConsole();
 
@@ -385,7 +385,7 @@ public:
 #if JUCE_WINDOWS
             auto buildScript = make.getFullPathName().replaceCharacter('\\', '/')
                 + " -j4 -f "
-                + sourceDir.getChildFile("Makefile").getFullPathName().replaceCharacter('\\', '/')
+                + sourceDir.getChildFile("Makefile").getFullPathName().replaceCharacter('\\', '/').quoted()
                 + " GCC_PATH="
                 + gccPath.replaceCharacter('\\', '/')
                 + " PROJECT_NAME=" + name;
@@ -393,7 +393,7 @@ public:
             Toolchain::startShellScript(buildScript, this);
 #else
             String buildScript = make.getFullPathName()
-                + " -j4 -f " + sourceDir.getChildFile("Makefile").getFullPathName()
+                + " -j4 -f " + sourceDir.getChildFile("Makefile").getFullPathName().quoted()
                 + " GCC_PATH=" + gccPath
                 + " PROJECT_NAME=" + name;
 

--- a/Source/Heavy/DaisyExporter.h
+++ b/Source/Heavy/DaisyExporter.h
@@ -249,8 +249,8 @@ public:
         auto size = getValue<int>(patchSizeValue);
         auto appType = getValue<int>(appTypeValue);
 
-        
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir};
+
+        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir.quoted()};
 
         name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
@@ -337,15 +337,14 @@ public:
         args.add("-v");
         args.add("-gdaisy");
 
-        String paths = "-p";
+        args.add("-p");
         for (auto& path : searchPaths) {
-            paths += " " + path;
+            args.add(path);
         }
 
-        args.add(paths);
-
-        exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
-        start(args);
+        auto const command = args.joinIntoString(" ");
+        exportingView->logToConsole("Command: " + command + "\n");
+        Toolchain::startShellScript(command, this);
         waitForProcessToFinish(-1);
         exportingView->flushConsole();
 

--- a/Source/Heavy/DaisyExporter.h
+++ b/Source/Heavy/DaisyExporter.h
@@ -386,6 +386,7 @@ public:
             auto buildScript = make.getFullPathName().replaceCharacter('\\', '/')
                 + " -j4 -f "
                 + sourceDir.getChildFile("Makefile").getFullPathName().replaceCharacter('\\', '/').quoted()
+                + " SHELL=" + Toolchain::dir.getChildFile("bin").getChildFile("bash.exe").getFullPathName().replaceCharacter('\\', '/').quoted()
                 + " GCC_PATH="
                 + gccPath.replaceCharacter('\\', '/')
                 + " PROJECT_NAME=" + name;

--- a/Source/Heavy/DaisyExporter.h
+++ b/Source/Heavy/DaisyExporter.h
@@ -254,7 +254,7 @@ public:
 #else
         auto const heavyPath = heavyExecutable.getFullPathName();
 #endif
-        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
+        StringArray args = { heavyPath.quoted(), pdPatch.quoted(), "-o", outdir.quoted() };
 
         args.add("-n" + name);
 

--- a/Source/Heavy/DaisyExporter.h
+++ b/Source/Heavy/DaisyExporter.h
@@ -237,7 +237,7 @@ public:
         return getExitCode();
     }
 
-    bool performExport(String pdPatch, String outdir, String name, String copyright, StringArray searchPaths) override
+    bool performExport(String const& pdPatch, String const& outdir, String const& name, String const& copyright, StringArray const& searchPaths) override
     {
         auto target = getValue<int>(targetBoardValue) - 1;
         bool compile = getValue<int>(exportTypeValue) - 1;
@@ -248,11 +248,14 @@ public:
         auto rate = getValue<int>(samplerateValue) - 1;
         auto size = getValue<int>(patchSizeValue);
         auto appType = getValue<int>(appTypeValue);
+        
+#if JUCE_WINDOWS
+        auto const heavyPath = heavyExecutable.getFullPathName().replaceCharacter('\\', '/');
+#else
+        auto const heavyPath = heavyExecutable.getFullPathName();
+#endif
+        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
 
-
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir.quoted()};
-
-        name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {

--- a/Source/Heavy/ExporterBase.h
+++ b/Source/Heavy/ExporterBase.h
@@ -143,7 +143,11 @@ struct ExporterBase : public Component
         auto searchPaths = StringArray {};
         if (realPatchFile.existsAsFile() && !realPatchFile.isRoot())
         {
+#if JUCE_WINDOWS
             searchPaths.add(realPatchFile.getParentDirectory().getFullPathName().replaceCharacter('\\', '/').quoted());
+#else
+            searchPaths.add(realPatchFile.getParentDirectory().getFullPathName().quoted());
+#endif
         }
         editor->pd->setThis();
 

--- a/Source/Heavy/ExporterBase.h
+++ b/Source/Heavy/ExporterBase.h
@@ -140,7 +140,7 @@ struct ExporterBase : public Component
         }
 
         // Add original file location to search paths
-        auto searchPaths = StringArray { realPatchFile.getParentDirectory().getFullPathName() };
+        auto searchPaths = StringArray { realPatchFile.getParentDirectory().getFullPathName().quoted()};
 
         editor->pd->setThis();
 
@@ -149,12 +149,8 @@ struct ExporterBase : public Component
         int numItems;
         pd::Interface::getSearchPaths(paths, &numItems);
 
-        if (realPatchFile.existsAsFile()) {
-            searchPaths.add(realPatchFile.getParentDirectory().getFullPathName());
-        }
-
         for (int i = 0; i < numItems; i++) {
-            searchPaths.add(paths[i]);
+            searchPaths.add(String(paths[i]).quoted());
         }
 
         // Make sure we don't add the file location twice

--- a/Source/Heavy/ExporterBase.h
+++ b/Source/Heavy/ExporterBase.h
@@ -140,8 +140,11 @@ struct ExporterBase : public Component
         }
 
         // Add original file location to search paths
-        auto searchPaths = StringArray { realPatchFile.getParentDirectory().getFullPathName().quoted()};
-
+        auto searchPaths = StringArray {};
+        if (realPatchFile.existsAsFile() && !realPatchFile.isRoot())
+        {
+            searchPaths.add(realPatchFile.getParentDirectory().getFullPathName().replaceCharacter('\\', '/').quoted());
+        }
         editor->pd->setThis();
 
         // Get pd's search paths

--- a/Source/Heavy/OWLExporter.h
+++ b/Source/Heavy/OWLExporter.h
@@ -99,7 +99,7 @@ public:
 #else
         auto const heavyPath = heavyExecutable.getFullPathName();
 #endif
-        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
+        StringArray args = { heavyPath.quoted(), pdPatch.quoted(), "-o", outdir.quoted() };
 
         args.add("-n" + name);
 

--- a/Source/Heavy/OWLExporter.h
+++ b/Source/Heavy/OWLExporter.h
@@ -107,12 +107,10 @@ public:
         args.add("-v");
         args.add("-gOWL");
 
-        String paths = "-p";
+        args.add("-p");
         for (auto& path : searchPaths) {
-            paths += " " + path;
+            args.add(path);
         }
-
-        args.add(paths);
 
         exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
         start(args);

--- a/Source/Heavy/OWLExporter.h
+++ b/Source/Heavy/OWLExporter.h
@@ -94,14 +94,14 @@ public:
         bool store = getValue<int>(exportTypeValue) == 4;
         int slot = getValue<int>(storeSlotValue);
 
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o" + outdir };
+        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
 
         name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {
             args.add("--copyright");
-            args.add("\"" + copyright + "\"");
+            args.add(copyright.quoted());
         }
 
         args.add("-v");
@@ -114,9 +114,8 @@ public:
 
         args.add(paths);
 
-        auto compileString = args.joinIntoString(" ");
-        exportingView->logToConsole("Command: " + compileString + "\n");
-        start(compileString);
+        exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
+        start(args);
 
         waitForProcessToFinish(-1);
         exportingView->flushConsole();

--- a/Source/Heavy/OWLExporter.h
+++ b/Source/Heavy/OWLExporter.h
@@ -86,7 +86,7 @@ public:
         storeSlotProperty->setEnabled(exportType == 4);
     }
 
-    bool performExport(String pdPatch, String outdir, String name, String copyright, StringArray searchPaths) override
+    bool performExport(String const& pdPatch, String const& outdir, String const& name, String const& copyright, StringArray const& searchPaths) override
     {
         auto target = getValue<int>(targetBoardValue);
         bool compile = getValue<int>(exportTypeValue) - 1;
@@ -94,9 +94,13 @@ public:
         bool store = getValue<int>(exportTypeValue) == 4;
         int slot = getValue<int>(storeSlotValue);
 
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
+#if JUCE_WINDOWS
+        auto const heavyPath = heavyExecutable.getFullPathName().replaceCharacter('\\', '/');
+#else
+        auto const heavyPath = heavyExecutable.getFullPathName();
+#endif
+        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
 
-        name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {

--- a/Source/Heavy/OWLExporter.h
+++ b/Source/Heavy/OWLExporter.h
@@ -163,7 +163,8 @@ public:
                 + " BUILD=../"
                 + " PATCHNAME=" + name
                 + " PATCHCLASS=HeavyPatch"
-                + " PATCHFILE=HeavyOWL_" + name + ".hpp";
+                + " PATCHFILE=HeavyOWL_" + name + ".hpp"
+                + " SHELL=" + Toolchain::dir.getChildFile("bin").getChildFile("bash.exe").getFullPathName().replaceCharacter('\\', '/').quoted();
 #else
             buildScript += make.getFullPathName()
                 + " -j4"

--- a/Source/Heavy/PdExporter.h
+++ b/Source/Heavy/PdExporter.h
@@ -61,13 +61,17 @@ public:
         }
     }
 
-    bool performExport(String pdPatch, String const outdir, String name, String const copyright, StringArray searchPaths) override
+    bool performExport(String const& pdPatch, String const& outdir, String const &name, String const& copyright, StringArray const& searchPaths) override
     {
         exportingView->showState(ExportingProgressView::Exporting);
 
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
+#if JUCE_WINDOWS
+        auto const heavyPath = heavyExecutable.getFullPathName().replaceCharacter('\\', '/');
+#else
+        auto const heavyPath = heavyExecutable.getFullPathName();
+#endif
+        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
 
-        name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {

--- a/Source/Heavy/PdExporter.h
+++ b/Source/Heavy/PdExporter.h
@@ -70,7 +70,7 @@ public:
 #else
         auto const heavyPath = heavyExecutable.getFullPathName();
 #endif
-        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
+        StringArray args = { heavyPath.quoted(), pdPatch.quoted(), "-o", outdir.quoted() };
 
         args.add("-n" + name);
 

--- a/Source/Heavy/PdExporter.h
+++ b/Source/Heavy/PdExporter.h
@@ -129,8 +129,9 @@ public:
             auto cc = "CC=" + Toolchain::dir.getChildFile("bin").getChildFile("gcc.exe").getFullPathName().replaceCharacter('\\', '/') + " ";
             auto cxx = "CXX=" + Toolchain::dir.getChildFile("bin").getChildFile("g++.exe").getFullPathName().replaceCharacter('\\', '/') + " ";
             auto pdbindir = "PDBINDIR=\"" + pdDll.getFullPathName().replaceCharacter('\\', '/') + "\" ";
+            auto shell = " SHELL=" + Toolchain::dir.getChildFile("bin").getChildFile("bash.exe").getFullPathName().replaceCharacter('\\', '/').quoted();
 
-            Toolchain::startShellScript(path + cc + cxx + pdbindir + make.getFullPathName().replaceCharacter('\\', '/') + " -j4", this);
+            Toolchain::startShellScript(path + cc + cxx + pdbindir + make.getFullPathName().replaceCharacter('\\', '/') + " -j4" + shell, this);
 
 #else // Linux or BSD
             auto prepareEnvironmentScript = Toolchain::dir.getChildFile("scripts").getChildFile("anywhere-setup.sh").getFullPathName() + "\n";

--- a/Source/Heavy/PdExporter.h
+++ b/Source/Heavy/PdExporter.h
@@ -78,18 +78,17 @@ public:
         args.add("-v");
         args.add("-gpdext");
 
-        String paths = "-p";
+        args.add("-p");
         for (auto& path : searchPaths) {
-            paths += " " + path;
+            args.add(path);
         }
-
-        args.add(paths);
 
         if (shouldQuit)
             return true;
 
-        exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
-        start(args);
+        auto const command = args.joinIntoString(" ");
+        exportingView->logToConsole("Command: " + command + "\n");
+        Toolchain::startShellScript(command, this);
 
         waitForProcessToFinish(-1);
         exportingView->flushConsole();

--- a/Source/Heavy/PdExporter.h
+++ b/Source/Heavy/PdExporter.h
@@ -65,14 +65,14 @@ public:
     {
         exportingView->showState(ExportingProgressView::Exporting);
 
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o" + outdir };
+        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
 
         name = name.replaceCharacter('-', '_');
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {
             args.add("--copyright");
-            args.add("\"" + copyright + "\"");
+            args.add(copyright.quoted());
         }
 
         args.add("-v");
@@ -88,9 +88,8 @@ public:
         if (shouldQuit)
             return true;
 
-        auto compileString = args.joinIntoString(" ");
-        exportingView->logToConsole("Command: " + compileString + "\n");
-        start(compileString);
+        exportingView->logToConsole("Command: " + args.joinIntoString(" ") + "\n");
+        start(args);
 
         waitForProcessToFinish(-1);
         exportingView->flushConsole();

--- a/Source/Heavy/Toolchain.h
+++ b/Source/Heavy/Toolchain.h
@@ -330,7 +330,7 @@ public:
 #elif JUCE_MAC
     String downloadSize = "460 MB";
 #else
-    String downloadSize = "805 MB";
+    String downloadSize = "799 MB";
 #endif
 
     class ToolchainInstallerButton final : public Component {

--- a/Source/Heavy/WASMExporter.h
+++ b/Source/Heavy/WASMExporter.h
@@ -65,7 +65,7 @@ public:
 #if JUCE_WINDOWS
         StringArray args = { heavyExecutable.getFullPathName().replaceCharacter('\\', '/'), pdPatch.replaceCharacter('\\', '/'), "-o" + outdir.replaceCharacter('\\', '/') };
 #else
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o" + outdir };
+        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
 #endif
 
         name = name.replaceCharacter('-', '_');
@@ -73,7 +73,7 @@ public:
 
         if (copyright.isNotEmpty()) {
             args.add("--copyright");
-            args.add("\"" + copyright + "\"");
+            args.add(copyright.quoted());
         }
 
         auto emsdkPath = getValue<String>(emsdkPathValue);

--- a/Source/Heavy/WASMExporter.h
+++ b/Source/Heavy/WASMExporter.h
@@ -67,7 +67,7 @@ public:
 #else
         auto const heavyPath = heavyExecutable.getFullPathName();
 #endif
-        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
+        StringArray args = { heavyPath.quoted(), pdPatch.quoted(), "-o", outdir.quoted() };
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {

--- a/Source/Heavy/WASMExporter.h
+++ b/Source/Heavy/WASMExporter.h
@@ -58,17 +58,16 @@ public:
         }
     }
 
-    bool performExport(String pdPatch, String outdir, String name, String copyright, StringArray searchPaths) override
+    bool performExport(String const& pdPatch, String const& outdir, String const& name, String const& copyright, StringArray const& searchPaths) override
     {
         exportingView->showState(ExportingProgressView::Exporting);
 
-#if JUCE_WINDOWS
-        StringArray args = { heavyExecutable.getFullPathName().replaceCharacter('\\', '/'), pdPatch.replaceCharacter('\\', '/'), "-o" + outdir.replaceCharacter('\\', '/') };
+        #if JUCE_WINDOWS
+        auto const heavyPath = heavyExecutable.getFullPathName().replaceCharacter('\\', '/');
 #else
-        StringArray args = { heavyExecutable.getFullPathName(), pdPatch, "-o", outdir };
+        auto const heavyPath = heavyExecutable.getFullPathName();
 #endif
-
-        name = name.replaceCharacter('-', '_');
+        StringArray args = { heavyPath, pdPatch, "-o", outdir.quoted() };
         args.add("-n" + name);
 
         if (copyright.isNotEmpty()) {

--- a/Source/Heavy/WASMExporter.h
+++ b/Source/Heavy/WASMExporter.h
@@ -81,16 +81,10 @@ public:
         args.add("-v");
         args.add("-gjs");
 
-        String paths = "-p";
+        args.add("-p");
         for (auto& path : searchPaths) {
-#if JUCE_WINDOWS
-            paths += " " + path.replaceCharacter('\\', '/');
-#else
-            paths += " " + path;
-#endif
+            args.add(path);
         }
-
-        args.add(paths);
 
         if (shouldQuit)
             return true;


### PR DESCRIPTION
- Spaces in paths are now handled correctly (search paths, output paths, patch paths, etc.)
- Fixes obscure Windows issue where it uses the wrong shell
- Small clean up and optimisation for exporter arguments