### PR TITLE
feat: add Cmd/Ctrl+Shift+C keyboard shortcut to open compile window

### DIFF
--- a/Source/Constants.h
+++ b/Source/Constants.h
@@ -383,6 +383,7 @@ enum CommandIDs {
     ToggleDSP,
     TogglePresentationMode,
     TogglePluginMode,
+    Compile,
     NumItems // <-- the total number of items in this enum
 };
 

--- a/Source/Dialogs/MainMenu.h
+++ b/Source/Dialogs/MainMenu.h
@@ -105,7 +105,6 @@ public:
         menuItems[getMenuItemIndex(MenuItem::SaveAs)]->isActive = hasCanvas;
 
         menuItems[getMenuItemIndex(MenuItem::CompiledMode)]->isTicked = hvccModeEnabled;
-        menuItems[getMenuItemIndex(MenuItem::Compile)]->isActive = hvccModeEnabled;
     }
 
     class IconMenuItem final : public PopupMenu::CustomComponent {

--- a/Source/Dialogs/MainMenu.h
+++ b/Source/Dialogs/MainMenu.h
@@ -105,6 +105,7 @@ public:
         menuItems[getMenuItemIndex(MenuItem::SaveAs)]->isActive = hasCanvas;
 
         menuItems[getMenuItemIndex(MenuItem::CompiledMode)]->isTicked = hvccModeEnabled;
+        menuItems[getMenuItemIndex(MenuItem::Compile)]->isActive = hvccModeEnabled;
     }
 
     class IconMenuItem final : public PopupMenu::CustomComponent {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1529,7 +1529,7 @@ void PluginEditor::getCommandInfo(CommandID const commandID, ApplicationCommandI
     case CommandIDs::Compile: {
         result.setInfo("Compile...", "Open Heavy export dialog", "General", 0);
         result.addDefaultKeypress(67, ModifierKeys::commandModifier | ModifierKeys::shiftModifier);
-        result.setActive(SettingsFile::getInstance()->getProperty<bool>("hvcc_mode"));
+        result.setActive(true);
         break;
     }
     default:

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1526,6 +1526,12 @@ void PluginEditor::getCommandInfo(CommandID const commandID, ApplicationCommandI
         result.setActive(true);
         break;
     }
+    case CommandIDs::Compile: {
+        result.setInfo("Compile...", "Open Heavy export dialog", "General", 0);
+        result.addDefaultKeypress(67, ModifierKeys::commandModifier | ModifierKeys::shiftModifier);
+        result.setActive(SettingsFile::getInstance()->getProperty<bool>("hvcc_mode"));
+        break;
+    }
     default:
         break;
     }
@@ -1914,6 +1920,10 @@ bool PluginEditor::perform(InvocationInfo const& info)
         } else {
             getTabComponent().openInPluginMode(getCurrentCanvas()->refCountedPatch);
         }
+        return true;
+    }
+    case CommandIDs::Compile: {
+        Dialogs::showHeavyExportDialog(&openedDialog, this);
         return true;
     }
     default: {


### PR DESCRIPTION
# Description

This PR adds the Cmd/Ctrl + Shift + C keyboard shortcut to trigger the compile export dialog.

The shortcut choice must be validated.

Related to issue #2344 

# Changes

- Source/Constants.h: Registered new command ID `CommandIDs::Compile`
- Source/PluginEditor.cpp:
	- Registered command metadata, default keypress combination Cmd/Ctrl + Shift + C, and conditional active state based on `hvcc_mode (SettingsFile::getInstance()->getProperty<bool>("hvcc_mode"))` in `getCommandInfo`
	- Wired command execution to open the Heavy export dialog via `Dialogs::showHeavyExportDialog(&openedDialog, this)` in `perform`

# What I've tested

Tested on Windows 11 only. Needs more testing on Mac and Linux!

1. Compiled Mode ON:
    - Pressed Cmd/Ctrl + Shift + C.
    - Result: The Heavy export dialog opens immediately.
3. Compiled Mode OFF:
    - Pressed Cmd/Ctrl + Shift + C.
    - Result: The Heavy export dialog opens immediately.
5. Option Persistence:
    - Opened Heavy export dialog using Cmd/Ctrl + Shift + C.
    - Modified compiler options.
    - Closed the dialog and re-opened it using Cmd/Ctrl + Shift + C.
    - Result: All user-selected compiler settings and options remain preserved without resetting.

# Next steps

- Maybe add a shortcut to export without the need to open the compile window?